### PR TITLE
Update PowerShell module packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,4 +111,7 @@ jobs:
           New-Item -Path artifacts/ci-nuget -ItemType Directory -Force | Out-Null
           dotnet pack dotnet/src/Devolutions.Pinget.Core/Devolutions.Pinget.Core.csproj -c Release --no-build -o artifacts/ci-nuget
           dotnet pack dotnet/src/Devolutions.Pinget.PowerShell.Engine/Devolutions.Pinget.PowerShell.Engine.csproj -c Release --no-build -o artifacts/ci-nuget
-          dotnet pack dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Devolutions.Pinget.PowerShell.Cmdlets.csproj -c Release --no-build -o artifacts/ci-nuget
+
+      - name: Validate PowerShell module packaging
+        shell: pwsh
+        run: pwsh -NoLogo -NoProfile -File (Resolve-Path 'scripts/Build-PowerShellModule.ps1') -NoBuild -OutputRoot artifacts/ci-powershell -Clean

--- a/.github/workflows/parity-test.yml
+++ b/.github/workflows/parity-test.yml
@@ -43,11 +43,12 @@ jobs:
         shell: pwsh
         run: |
           dotnet build dotnet/Devolutions.Pinget.slnx -c Release
+          pwsh -NoLogo -NoProfile -File (Resolve-Path 'scripts/Build-PowerShellModule.ps1') -NoBuild -OutputRoot dist/powershell-module -Clean
 
       - name: Run Windows parity coherence tests
         shell: pwsh
         run: |
           $rustPinget = Resolve-Path 'rust/target/debug/pinget.exe'
           $dotnetPinget = Resolve-Path 'dotnet/src/Devolutions.Pinget.Cli/bin/Release/net10.0/pinget.exe'
-          $pingetModule = Resolve-Path 'dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/bin/Release/net8.0/Pinget.psd1'
+          $pingetModule = Resolve-Path 'dist/powershell-module/Devolutions.Pinget.Client/Devolutions.Pinget.Client.psd1'
           pwsh -NoLogo -NoProfile -File (Resolve-Path 'scripts/Parity-Compare-WingetParity.ps1') -RustWinget $rustPinget -DotnetWinget $dotnetPinget -PowerShellModulePath $pingetModule

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: false
         type: boolean
+      publish-powershell-gallery:
+        description: Publish Devolutions.Pinget.Client to PowerShell Gallery during a manual release.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -37,6 +42,7 @@ jobs:
       tag-name: ${{ steps.info.outputs.tag-name }}
       dry-run: ${{ steps.info.outputs.dry-run }}
       publish-nuget: ${{ steps.info.outputs.publish-nuget }}
+      publish-powershell-gallery: ${{ steps.info.outputs.publish-powershell-gallery }}
 
     steps:
       - name: Checkout
@@ -51,19 +57,23 @@ jobs:
 
           $DryRun = $false
           $PublishNuget = $true
+          $PublishPowerShellGallery = $true
 
           if ($IsWorkflowDispatch) {
             try { $DryRun = [System.Boolean]::Parse('${{ inputs['dry-run'] }}') } catch { $DryRun = $true }
             try { $PublishNuget = [System.Boolean]::Parse('${{ inputs['publish-nuget'] }}') } catch { $PublishNuget = $false }
+            try { $PublishPowerShellGallery = [System.Boolean]::Parse('${{ inputs['publish-powershell-gallery'] }}') } catch { $PublishPowerShellGallery = $false }
           }
 
           if (-not $IsMasterBranch) {
             $DryRun = $true
             $PublishNuget = $false
+            $PublishPowerShellGallery = $false
           }
 
           if ($DryRun) {
             $PublishNuget = $false
+            $PublishPowerShellGallery = $false
           }
 
           $Version = '${{ inputs.version }}'
@@ -97,11 +107,13 @@ jobs:
           "tag-name=$TagName" >> $Env:GITHUB_OUTPUT
           "dry-run=$($DryRun.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
           "publish-nuget=$($PublishNuget.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
+          "publish-powershell-gallery=$($PublishPowerShellGallery.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
 
           Write-Host "::notice::Version: $Version"
           Write-Host "::notice::Tag: $TagName"
           Write-Host "::notice::DryRun: $DryRun"
           Write-Host "::notice::PublishNuget: $PublishNuget"
+          Write-Host "::notice::PublishPowerShellGallery: $PublishPowerShellGallery"
 
   rust-artifacts:
     name: Rust Artifacts (${{ matrix.name }})
@@ -258,39 +270,14 @@ jobs:
           $packArgs = @('-c', 'Release', '--no-build', '-p:ContinuousIntegrationBuild=true', "-p:Version=$env:PACKAGE_VERSION", '-p:IncludeSymbols=true', '-p:SymbolPackageFormat=snupkg', '-o', 'dist/nuget')
           dotnet pack dotnet/src/Devolutions.Pinget.Core/Devolutions.Pinget.Core.csproj @packArgs
           dotnet pack dotnet/src/Devolutions.Pinget.PowerShell.Engine/Devolutions.Pinget.PowerShell.Engine.csproj @packArgs
-          dotnet pack dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Devolutions.Pinget.PowerShell.Cmdlets.csproj @packArgs
 
       - name: Package PowerShell module
         shell: pwsh
         env:
           PACKAGE_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
-          Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-          $moduleName = 'Pinget'
-          $moduleVersion = $env:PACKAGE_VERSION
-          $moduleOutput = Join-Path 'dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/bin/Release' 'net8.0'
-          $stagingRoot = Join-Path 'dist' 'powershell-module'
-          $moduleRoot = Join-Path $stagingRoot $moduleName
-          $archivePath = Join-Path 'dist' ("pinget-powershell-module-$moduleVersion.zip")
-
-          if (-not (Test-Path -Path (Join-Path $moduleOutput 'Pinget.psd1'))) {
-            throw "PowerShell module manifest not found in $moduleOutput"
-          }
-
-          if (Test-Path -Path $stagingRoot) {
-            Remove-Item -Path $stagingRoot -Recurse -Force
-          }
-
-          if (Test-Path -Path $archivePath) {
-            Remove-Item -Path $archivePath -Force
-          }
-
-          New-Item -Path $moduleRoot -ItemType Directory -Force | Out-Null
-          Copy-Item -Path (Join-Path $moduleOutput '*') -Destination $moduleRoot -Recurse -Force
-          [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingRoot, $archivePath, [System.IO.Compression.CompressionLevel]::Optimal, $false)
-
-          Write-Host "Created $archivePath"
+          $archivePath = Join-Path 'dist' "Devolutions.Pinget.Client.$env:PACKAGE_VERSION.zip"
+          pwsh -NoLogo -NoProfile -File (Resolve-Path 'scripts/Build-PowerShellModule.ps1') -NoBuild -Version $env:PACKAGE_VERSION -OutputRoot dist/powershell-module -ArchivePath $archivePath -Clean
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7
@@ -305,7 +292,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: powershell-module
-          path: dist/pinget-powershell-module-*.zip
+          path: dist/Devolutions.Pinget.Client.*.zip
           if-no-files-found: error
 
   create-tag:
@@ -365,6 +352,8 @@ jobs:
   publish-nuget:
     name: Publish NuGet
     runs-on: ubuntu-latest
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     needs:
       - preflight
       - csharp-packages
@@ -387,8 +376,41 @@ jobs:
       - name: Push packages to NuGet.org
         if: env.NUGET_API_KEY != ''
         shell: bash
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           dotnet nuget push dist/nuget/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
           dotnet nuget push dist/nuget/*.snupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  publish-powershell-gallery:
+    name: Publish PowerShell Gallery
+    runs-on: ubuntu-latest
+    env:
+      PS_GALLERY_API_KEY: ${{ secrets.PS_GALLERY_API_KEY }}
+    needs:
+      - preflight
+      - csharp-packages
+      - create-tag
+      - github-release
+    if: ${{ fromJSON(needs.preflight.outputs.dry-run) == false && fromJSON(needs.preflight.outputs.publish-powershell-gallery) == true }}
+
+    steps:
+      - name: Download PowerShell module artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: powershell-module
+          path: dist/powershell-module
+
+      - name: Publish Devolutions.Pinget.Client to PowerShell Gallery
+        if: env.PS_GALLERY_API_KEY != ''
+        shell: pwsh
+        run: |
+          $archive = Get-ChildItem -Path dist/powershell-module -Filter 'Devolutions.Pinget.Client.*.zip' | Select-Object -First 1
+          if ($null -eq $archive) {
+            throw 'PowerShell module archive was not downloaded.'
+          }
+
+          $expandedRoot = Join-Path 'dist' 'powershell-gallery'
+          Expand-Archive -Path $archive.FullName -DestinationPath $expandedRoot -Force
+          $modulePath = (Resolve-Path (Join-Path $expandedRoot 'Devolutions.Pinget.Client')).Path
+
+          Test-ModuleManifest -Path (Join-Path $modulePath 'Devolutions.Pinget.Client.psd1') | Out-Null
+          Publish-Module -Path $modulePath -NuGetApiKey $env:PS_GALLERY_API_KEY -Verbose

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pinget
 
-This directory contains **Pinget**: portable, COM-free WinGet-compatible implementations intended to become a standalone repository later.
+This directory contains **Pinget**: portable implementations intended to remain compatible with WinGet behavior where practical.
 
-The current goal is to keep the subtree self-contained enough that it can be split out with minimal rewriting. Within this directory, treat paths as if `pinget\` were the repository root.
+The current goal is to keep the Rust, C#, and PowerShell surfaces aligned while preserving WinGet-compatible behavior. Within this directory, treat paths as if `pinget\` were the repository root.
 
 ## Layout
 
@@ -120,9 +120,9 @@ dotnet run --project dotnet\src\Devolutions.Pinget.Cli\Devolutions.Pinget.Cli.cs
 - `dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets` - PowerShell cmdlet implementation for the `Devolutions.Pinget.Client` module
 - `dotnet\tests` - Pinget PowerShell Pester coverage
 
-## Extraction prep
+## Compatibility guidance
 
-This subtree is being prepared for later promotion into its own GitHub repository. Current prep rules:
+Pinget is maintained with WinGet compatibility in mind. Current prep rules:
 
 1. Prefer subtree-relative paths in docs and scripts.
 2. Keep Pinget-specific documentation under this directory instead of the parent repo when practical.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The current goal is to keep the subtree self-contained enough that it can be spl
 | Path | Language | Output | Notes |
 | --- | --- | --- | --- |
 | `rust` | Rust | `pinget` CLI + `pinget-core` library | Cargo workspace with a reusable core crate and a CLI crate |
-| `dotnet` | C# / .NET 10 | `pinget` CLI + `Devolutions.Pinget.Core` library + Pinget PowerShell module | Solution with a reusable core library, CLI app, tests, and a PowerShell engine/cmdlet layer |
+| `dotnet` | C# / .NET 10 | `pinget` CLI + `Devolutions.Pinget.Core` library + `Devolutions.Pinget.Client` PowerShell module | Solution with a reusable core library, CLI app, tests, and a PowerShell engine/cmdlet layer |
 
 ## Current scope
 
@@ -27,7 +27,7 @@ Structured manifest output is also supported:
 - `show --output json|yaml`
 - `search --manifests --output json|yaml`
 
-The C# implementation also ships a **Pinget PowerShell module** that mirrors the upstream `Microsoft.WinGet.Client` cmdlet family with renamed `Pinget` nouns, backed entirely by `Devolutions.Pinget.Core` rather than COM / WinRT APIs.
+The C# implementation also ships the **`Devolutions.Pinget.Client` PowerShell 7 module** that mirrors the upstream `Microsoft.WinGet.Client` cmdlet family with renamed `Pinget` nouns, backed entirely by `Devolutions.Pinget.Core` rather than COM / WinRT APIs.
 
 ## Non-goals
 
@@ -94,6 +94,7 @@ dotnet format dotnet\Devolutions.Pinget.slnx
 dotnet build dotnet\Devolutions.Pinget.slnx -c Release
 dotnet test dotnet\src\Devolutions.Pinget.Core.Tests\Devolutions.Pinget.Core.Tests.csproj -c Release
 pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet\tests\RunTests.ps1')
+pwsh -NoLogo -NoProfile -File (Resolve-Path 'scripts\Build-PowerShellModule.ps1') -NoBuild -OutputRoot dist\powershell-module -Clean
 ```
 
 Run:
@@ -116,7 +117,7 @@ dotnet run --project dotnet\src\Devolutions.Pinget.Cli\Devolutions.Pinget.Cli.cs
 - `dotnet\src\Devolutions.Pinget.Cli` - `Devolutions.Pinget.Cli` wrapper
 - `dotnet\src\Devolutions.Pinget.Core.Tests` - unit tests
 - `dotnet\src\Devolutions.Pinget.PowerShell.Engine` - PowerShell engine over the C# core
-- `dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets` - PowerShell cmdlet implementation
+- `dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets` - PowerShell cmdlet implementation for the `Devolutions.Pinget.Client` module
 - `dotnet\tests` - Pinget PowerShell Pester coverage
 
 ## Extraction prep

--- a/dotnet/src/Devolutions.Pinget.Core/Repository.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Repository.cs
@@ -1,8 +1,8 @@
-using System.Runtime.InteropServices;
 using System.Reflection;
-using System.Threading;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json.Nodes;
+using System.Threading;
 using Microsoft.Data.Sqlite;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
@@ -12,6 +12,8 @@ namespace Devolutions.Pinget.Core;
 
 public class Repository : IDisposable
 {
+    private const string AppRootEnvironmentVariable = "PINGET_APPROOT";
+
     internal const string InstalledStateUnsupportedWarning = "Installed package discovery is not supported on this platform; returning no installed packages.";
     internal const string InstallUnsupportedWarning = "Installing packages is not supported on this platform; no changes were made.";
     internal const string UninstallUnsupportedWarning = "Uninstalling packages is not supported on this platform; no changes were made.";
@@ -38,7 +40,7 @@ public class Repository : IDisposable
     {
         options ??= new RepositoryOptions();
         EnsureSqliteNativeLibraryLoaded();
-        var appRoot = SourceStoreManager.NormalizeAppRoot(options.AppRoot);
+        var appRoot = SourceStoreManager.NormalizeAppRoot(options.AppRoot ?? Environment.GetEnvironmentVariable(AppRootEnvironmentVariable));
         SourceStoreManager.EnsureAppDirs(appRoot);
         var store = SourceStoreManager.Load(appRoot);
         var client = new HttpClient();

--- a/dotnet/src/Devolutions.Pinget.Core/SourceStore.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/SourceStore.cs
@@ -1,6 +1,6 @@
+using System.Security.Principal;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Security.Principal;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -452,4 +452,4 @@ internal static class SourceStoreManager
 
     private static string SanitizePathSegment(string value) => string.Concat(value.Select(c =>
         @"\/:*?""<>|".Contains(c) ? '_' : c));
-    }
+}

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/AddSourceCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/AddSourceCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Add, Constants.PingetNouns.Source)]
-[Alias("apgs")]
 public sealed class AddSourceCmdlet : PSCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/AssertPackageManagerCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/AssertPackageManagerCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsLifecycle.Assert, Constants.PingetNouns.PingetPackageManager, DefaultParameterSetName = Constants.IntegrityVersionSet)]
-[Alias("apgpm")]
 public sealed class AssertPackageManagerCmdlet : PingetPackageManagerCmdlet
 {
     protected override void ProcessRecord()

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/DisableSettingCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/DisableSettingCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsLifecycle.Disable, Constants.PingetNouns.Setting)]
-[Alias("dpgs")]
 public sealed class DisableSettingCmdlet : PSCmdlet
 {
     [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/EnableSettingCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/EnableSettingCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsLifecycle.Enable, Constants.PingetNouns.Setting)]
-[Alias("epgs")]
 public sealed class EnableSettingCmdlet : PSCmdlet
 {
     [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/ExportPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/ExportPackageCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsData.Export, Constants.PingetNouns.Package, DefaultParameterSetName = Constants.FoundSet, SupportsShouldProcess = true)]
-[Alias("epgp")]
 [OutputType(typeof(PSDownloadResult))]
 public sealed class ExportPackageCmdlet : InstallerSelectionCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/FindPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/FindPackageCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Find, Constants.PingetNouns.Package)]
-[Alias("fdpgp")]
 [OutputType(typeof(PSFoundCatalogPackage))]
 public sealed class FindPackageCmdlet : FinderExtendedCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetPackageCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Get, Constants.PingetNouns.Package)]
-[Alias("gpgp")]
 [OutputType(typeof(PSInstalledCatalogPackage))]
 public sealed class GetPackageCmdlet : FinderExtendedCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetSettingCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetSettingCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Get, Constants.PingetNouns.Setting)]
-[Alias("gpgse", "Get-PingetSettings")]
 public sealed class GetSettingCmdlet : PSCmdlet
 {
     [Parameter(ValueFromPipelineByPropertyName = true)]

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetSourceCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetSourceCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Get, Constants.PingetNouns.Source)]
-[Alias("gpgso")]
 [OutputType(typeof(PSSourceResult))]
 public sealed class GetSourceCmdlet : PSCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetUserSettingCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetUserSettingCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Get, Constants.PingetNouns.UserSetting)]
-[Alias("gpgus", "Get-PingetUserSettings")]
 [OutputType(typeof(System.Collections.Hashtable))]
 public sealed class GetUserSettingCmdlet : PSCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetVersionCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/GetVersionCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Get, Constants.PingetNouns.Version)]
-[Alias("gpgv")]
 [OutputType(typeof(string))]
 public sealed class GetVersionCmdlet : PSCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/InstallPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/InstallPackageCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsLifecycle.Install, Constants.PingetNouns.Package, DefaultParameterSetName = Constants.FoundSet, SupportsShouldProcess = true)]
-[Alias("ispgp")]
 [OutputType(typeof(PSInstallResult))]
 public sealed class InstallPackageCmdlet : InstallCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/RemoveSourceCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/RemoveSourceCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Remove, Constants.PingetNouns.Source)]
-[Alias("rpgs")]
 public sealed class RemoveSourceCmdlet : PSCmdlet
 {
     [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/RepairPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/RepairPackageCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsDiagnostic.Repair, Constants.PingetNouns.Package, DefaultParameterSetName = Constants.FoundSet, SupportsShouldProcess = true)]
-[Alias("rpgp")]
 [OutputType(typeof(PSRepairResult))]
 public sealed class RepairPackageCmdlet : PackageCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/RepairPackageManagerCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/RepairPackageManagerCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsDiagnostic.Repair, Constants.PingetNouns.PingetPackageManager, DefaultParameterSetName = Constants.IntegrityVersionSet)]
-[Alias("rppgpm")]
 [OutputType(typeof(int))]
 public sealed class RepairPackageManagerCmdlet : PingetPackageManagerCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/ResetSourceCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/ResetSourceCmdlet.cs
@@ -5,7 +5,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Reset, Constants.PingetNouns.Source, DefaultParameterSetName = Constants.DefaultSet)]
-[Alias("rspgs")]
 public sealed class ResetSourceCmdlet : PSCmdlet
 {
     [Parameter(

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/SetUserSettingCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/SetUserSettingCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsCommon.Set, Constants.PingetNouns.UserSetting)]
-[Alias("spgus", "Set-PingetUserSettings")]
 [OutputType(typeof(Hashtable))]
 public sealed class SetUserSettingCmdlet : PSCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/TestUserSettingCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/TestUserSettingCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsDiagnostic.Test, Constants.PingetNouns.UserSetting)]
-[Alias("tpgus", "Test-PingetUserSettings")]
 [OutputType(typeof(bool))]
 public sealed class TestUserSettingCmdlet : PSCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/UninstallPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/UninstallPackageCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsLifecycle.Uninstall, Constants.PingetNouns.Package, DefaultParameterSetName = Constants.FoundSet, SupportsShouldProcess = true)]
-[Alias("uspgp")]
 [OutputType(typeof(PSUninstallResult))]
 public sealed class UninstallPackageCmdlet : PackageCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/UpdatePackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/UpdatePackageCmdlet.cs
@@ -6,7 +6,6 @@ using Devolutions.Pinget.PowerShell.Engine.PSObjects;
 namespace Devolutions.Pinget.PowerShell.Cmdlets.Cmdlets;
 
 [Cmdlet(VerbsData.Update, Constants.PingetNouns.Package, DefaultParameterSetName = Constants.FoundSet, SupportsShouldProcess = true)]
-[Alias("udpgp")]
 [OutputType(typeof(PSInstallResult))]
 public sealed class UpdatePackageCmdlet : InstallCmdlet
 {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Devolutions.Pinget.PowerShell.Cmdlets.csproj
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Devolutions.Pinget.PowerShell.Cmdlets.csproj
@@ -12,21 +12,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <IsPackable>true</IsPackable>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPowerShellModuleFilesToPackage</TargetsForTfmSpecificContentInPackage>
+    <IsPackable>false</IsPackable>
     <AssemblyName>Devolutions.Pinget.PowerShell.Cmdlets</AssemblyName>
     <RootNamespace>Devolutions.Pinget.PowerShell.Cmdlets</RootNamespace>
-    <PackageId>Devolutions.Pinget.PowerShell.Cmdlets</PackageId>
-    <Description>PowerShell cmdlets for Pinget.</Description>
+    <Description>PowerShell cmdlets for the Devolutions.Pinget.Client module.</Description>
   </PropertyGroup>
-
-  <Target Name="AddPowerShellModuleFilesToPackage">
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="$(ProjectDir)ModuleFiles\**\*.*">
-        <PackagePath>lib\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
-  </Target>
 
   <Target Name="CopyPowerShellModuleFiles" AfterTargets="AfterBuild">
     <ItemGroup>

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
@@ -6,7 +6,7 @@
     Author = 'Devolutions'
     CompanyName = 'Devolutions'
     Copyright = '(c) Devolutions. All rights reserved.'
-    Description = 'PowerShell 7 client module for Pinget, a COM-free WinGet-compatible package manager.'
+    Description = 'PowerShell 7 winget-compatible pinget module.'
     PowerShellVersion = '7.4.0'
 
     FunctionsToExport = @()
@@ -34,32 +34,7 @@
         'Export-PingetPackage'
     )
 
-    AliasesToExport = @(
-        'apgs'
-        'apgpm'
-        'dpgs'
-        'epgp'
-        'epgs'
-        'fdpgp'
-        'gpgp'
-        'gpgse'
-        'gpgso'
-        'gpgus'
-        'gpgv'
-        'ispgp'
-        'rpgp'
-        'rpgs'
-        'rppgpm'
-        'rspgs'
-        'spgus'
-        'tpgus'
-        'udpgp'
-        'uspgp'
-        'Get-PingetSettings'
-        'Get-PingetUserSettings'
-        'Set-PingetUserSettings'
-        'Test-PingetUserSettings'
-    )
+    AliasesToExport = @()
 
     FormatsToProcess = @('Format.ps1xml')
 

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
@@ -6,7 +6,7 @@
     Author = 'Devolutions'
     CompanyName = 'Devolutions'
     Copyright = '(c) Devolutions. All rights reserved.'
-    Description = 'PowerShell module for Pinget.'
+    Description = 'PowerShell 7 client module for Pinget, a COM-free WinGet-compatible package manager.'
     PowerShellVersion = '7.4.0'
 
     FunctionsToExport = @()
@@ -68,10 +68,14 @@
             Tags = @(
                 'PSEdition_Core'
                 'WindowsPackageManager'
+                'WinGet'
                 'Pinget'
                 'PortableWinget'
+                'PackageManagement'
             )
-            ProjectUri = 'https://github.com/microsoft/winget-cli'
+            LicenseUri = 'https://github.com/Devolutions/pinget/blob/master/LICENSE'
+            ProjectUri = 'https://github.com/Devolutions/pinget'
+            ReleaseNotes = 'See the repository changelog and release notes for details.'
         }
     }
 }

--- a/dotnet/tests/Pinget.PowerShell.Tests.ps1
+++ b/dotnet/tests/Pinget.PowerShell.Tests.ps1
@@ -79,13 +79,10 @@ Describe 'Pinget module exports' {
         }
     }
 
-    It 'exports the upstream-style plural aliases' {
+    It 'does not export aliases' {
         $aliases = (Get-Module Devolutions.Pinget.Client).ExportedAliases.Keys
 
-        $aliases | Should -Contain 'Get-PingetSettings'
-        $aliases | Should -Contain 'Get-PingetUserSettings'
-        $aliases | Should -Contain 'Set-PingetUserSettings'
-        $aliases | Should -Contain 'Test-PingetUserSettings'
+        $aliases | Should -BeNullOrEmpty
     }
 }
 

--- a/dotnet/tests/Pinget.PowerShell.Tests.ps1
+++ b/dotnet/tests/Pinget.PowerShell.Tests.ps1
@@ -6,12 +6,15 @@ param(
 
 BeforeAll {
     $script:previousLocalAppData = $env:LOCALAPPDATA
+    $script:previousPingetAppRoot = $env:PINGET_APPROOT
     $script:testRoot = Join-Path $env:TEMP "PingetPwshTests-$([guid]::NewGuid())"
+    $script:appRoot = Join-Path $script:testRoot 'app-root'
     $script:sourceName = 'PingetParitySource'
     $script:downloadDirectory = Join-Path $script:testRoot 'downloads'
 
-    New-Item -ItemType Directory -Force -Path $script:testRoot, $script:downloadDirectory | Out-Null
+    New-Item -ItemType Directory -Force -Path $script:testRoot, $script:appRoot, $script:downloadDirectory | Out-Null
     $env:LOCALAPPDATA = $script:testRoot
+    $env:PINGET_APPROOT = $script:appRoot
 
     Import-Module $ModulePath -Force
 
@@ -36,8 +39,9 @@ AfterAll {
     {
     }
 
-    Remove-Module Pinget -Force -ErrorAction SilentlyContinue
+    Remove-Module Devolutions.Pinget.Client -Force -ErrorAction SilentlyContinue
     $env:LOCALAPPDATA = $script:previousLocalAppData
+    $env:PINGET_APPROOT = $script:previousPingetAppRoot
 
     if (Test-Path $script:testRoot)
     {
@@ -47,7 +51,7 @@ AfterAll {
 
 Describe 'Pinget module exports' {
     It 'exports the renamed client cmdlets' {
-        $commands = Get-Command -Module Pinget | Select-Object -ExpandProperty Name
+        $commands = Get-Command -Module Devolutions.Pinget.Client | Select-Object -ExpandProperty Name
 
         @(
             'Get-PingetVersion'
@@ -76,7 +80,7 @@ Describe 'Pinget module exports' {
     }
 
     It 'exports the upstream-style plural aliases' {
-        $aliases = (Get-Module Pinget).ExportedAliases.Keys
+        $aliases = (Get-Module Devolutions.Pinget.Client).ExportedAliases.Keys
 
         $aliases | Should -Contain 'Get-PingetSettings'
         $aliases | Should -Contain 'Get-PingetUserSettings'
@@ -87,26 +91,26 @@ Describe 'Pinget module exports' {
 
 Describe 'Pinget command metadata' {
     It 'keeps Add-PingetSource compatibility parameters' {
-        $command = Get-Command Add-PingetSource -Module Pinget
+        $command = Get-Command Add-PingetSource -Module Devolutions.Pinget.Client
         $command.Parameters.Keys | Should -Contain 'TrustLevel'
         $command.Parameters.Keys | Should -Contain 'Explicit'
         $command.Parameters.Keys | Should -Contain 'Priority'
     }
 
     It 'keeps export installer selection parameters' {
-        $command = Get-Command Export-PingetPackage -Module Pinget
+        $command = Get-Command Export-PingetPackage -Module Devolutions.Pinget.Client
         $command.Parameters.Keys | Should -Contain 'AllowHashMismatch'
         $command.Parameters.Keys | Should -Contain 'Platform'
         $command.Parameters.Keys | Should -Contain 'TargetOSVersion'
     }
 
     It 'keeps install compatibility headers as a hashtable' {
-        $command = Get-Command Install-PingetPackage -Module Pinget
+        $command = Get-Command Install-PingetPackage -Module Devolutions.Pinget.Client
         $command.Parameters['Header'].ParameterType.FullName | Should -Be 'System.Collections.Hashtable'
     }
 
     It 'keeps Reset-PingetSource parameter sets' {
-        $command = Get-Command Reset-PingetSource -Module Pinget
+        $command = Get-Command Reset-PingetSource -Module Devolutions.Pinget.Client
 
         $command.DefaultParameterSet | Should -Be 'DefaultSet'
         ($command.ParameterSets | Select-Object -ExpandProperty Name) | Should -Contain 'DefaultSet'
@@ -114,9 +118,9 @@ Describe 'Pinget command metadata' {
     }
 
     It 'declares upstream-like output types for key commands' {
-        (Get-Command Get-PingetSource -Module Pinget).OutputType.Type.FullName | Should -Contain 'Devolutions.Pinget.PowerShell.Engine.PSObjects.PSSourceResult'
-        (Get-Command Find-PingetPackage -Module Pinget).OutputType.Type.FullName | Should -Contain 'Devolutions.Pinget.PowerShell.Engine.PSObjects.PSFoundCatalogPackage'
-        (Get-Command Export-PingetPackage -Module Pinget).OutputType.Type.FullName | Should -Contain 'Devolutions.Pinget.PowerShell.Engine.PSObjects.PSDownloadResult'
+        (Get-Command Get-PingetSource -Module Devolutions.Pinget.Client).OutputType.Type.FullName | Should -Contain 'Devolutions.Pinget.PowerShell.Engine.PSObjects.PSSourceResult'
+        (Get-Command Find-PingetPackage -Module Devolutions.Pinget.Client).OutputType.Type.FullName | Should -Contain 'Devolutions.Pinget.PowerShell.Engine.PSObjects.PSFoundCatalogPackage'
+        (Get-Command Export-PingetPackage -Module Devolutions.Pinget.Client).OutputType.Type.FullName | Should -Contain 'Devolutions.Pinget.PowerShell.Engine.PSObjects.PSDownloadResult'
     }
 }
 

--- a/dotnet/tests/RunTests.ps1
+++ b/dotnet/tests/RunTests.ps1
@@ -1,10 +1,16 @@
 [CmdletBinding()]
 param(
-    [string]$ModulePath = (Join-Path $PSScriptRoot '..\src\Devolutions.Pinget.PowerShell.Cmdlets\bin\Release\net8.0\Pinget.psd1'),
+    [string]$ModulePath = (Join-Path $PSScriptRoot '..\..\dist\powershell-module\Devolutions.Pinget.Client\Devolutions.Pinget.Client.psd1'),
     [string]$SourceArgument = 'https://api.winget.pro/4259fd23-6fcd-46bf-9287-be8833cfbdd5'
 )
 
 Import-Module Pester -MinimumVersion 5.0.0
+
+if (-not (Test-Path -Path $ModulePath))
+{
+    $buildModuleScript = Join-Path $PSScriptRoot '..\..\scripts\Build-PowerShellModule.ps1'
+    & $buildModuleScript -NoBuild -OutputRoot (Join-Path $PSScriptRoot '..\..\dist\powershell-module') -Clean | Out-Null
+}
 
 $config = New-PesterConfiguration
 $config.Run.Path = $PSScriptRoot

--- a/scripts/Build-PowerShellModule.ps1
+++ b/scripts/Build-PowerShellModule.ps1
@@ -1,0 +1,79 @@
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Release',
+    [string]$Framework = 'net8.0',
+    [string]$Version,
+    [string]$OutputRoot = (Join-Path $PSScriptRoot '..\dist\powershell-module'),
+    [string]$ArchivePath,
+    [switch]$NoBuild,
+    [switch]$Clean
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$moduleName = 'Devolutions.Pinget.Client'
+$projectPath = Join-Path $PSScriptRoot '..\dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\Devolutions.Pinget.PowerShell.Cmdlets.csproj'
+$buildOutput = Join-Path $PSScriptRoot "..\dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\bin\$Configuration\$Framework"
+$moduleRoot = Join-Path $OutputRoot $moduleName
+$moduleManifest = Join-Path $moduleRoot "$moduleName.psd1"
+
+if (-not $NoBuild) {
+    dotnet build $projectPath -c $Configuration -f $Framework
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet build failed with exit code $LASTEXITCODE."
+    }
+}
+
+$builtManifest = Join-Path $buildOutput "$moduleName.psd1"
+if (-not (Test-Path -Path $builtManifest)) {
+    throw "PowerShell module manifest not found: $builtManifest"
+}
+
+if ($Clean -and (Test-Path -Path $OutputRoot)) {
+    Remove-Item -Path $OutputRoot -Recurse -Force
+}
+
+New-Item -Path $moduleRoot -ItemType Directory -Force | Out-Null
+Copy-Item -Path (Join-Path $buildOutput '*') -Destination $moduleRoot -Recurse -Force
+Get-ChildItem -Path $moduleRoot -Filter '*.psd1' |
+    Where-Object { $_.Name -ne "$moduleName.psd1" } |
+    Remove-Item -Force
+
+if (-not [string]::IsNullOrWhiteSpace($Version)) {
+    if ($Version -notmatch '^([0-9]+(?:\.[0-9]+){1,3})(?:-.+)?$') {
+        throw "PowerShell module version '$Version' must start with a numeric module version."
+    }
+
+    $moduleVersion = $Matches[1]
+    $content = Get-Content -Path $moduleManifest -Raw
+    $content = $content -replace "ModuleVersion = '[^']+'", "ModuleVersion = '$moduleVersion'"
+    Set-Content -Path $moduleManifest -Value $content -Encoding utf8
+}
+
+$manifestInfo = Test-ModuleManifest -Path $moduleManifest
+if ($manifestInfo.Name -ne $moduleName) {
+    throw "Expected module '$moduleName' but manifest resolved to '$($manifestInfo.Name)'."
+}
+
+if ($manifestInfo.PowerShellVersion -lt [version]'7.4.0') {
+    throw "Expected the module to require PowerShell 7.4.0 or newer."
+}
+
+if (-not [string]::IsNullOrWhiteSpace($ArchivePath)) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $resolvedArchivePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($ArchivePath)
+    $archiveDirectory = Split-Path -Path $resolvedArchivePath -Parent
+    New-Item -Path $archiveDirectory -ItemType Directory -Force | Out-Null
+    if (Test-Path -Path $resolvedArchivePath) {
+        Remove-Item -Path $resolvedArchivePath -Force
+    }
+
+    [System.IO.Compression.ZipFile]::CreateFromDirectory(
+        (Resolve-Path -Path $OutputRoot).Path,
+        $resolvedArchivePath,
+        [System.IO.Compression.CompressionLevel]::Optimal,
+        $false)
+}
+
+Write-Output $moduleRoot

--- a/scripts/Parity-Compare-WingetParity.ps1
+++ b/scripts/Parity-Compare-WingetParity.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$RustWinget = (Join-Path $PSScriptRoot "..\target\debug\pinget.exe"),
     [string]$DotnetWinget = (Join-Path $PSScriptRoot "..\..\dotnet\src\Devolutions.Pinget.Cli\bin\Release\net10.0\pinget.exe"),
-    [string]$PowerShellModulePath = (Join-Path $PSScriptRoot "..\..\dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\bin\Release\net10.0\Pinget.psd1"),
+    [string]$PowerShellModulePath = (Join-Path $PSScriptRoot "..\dist\powershell-module\Devolutions.Pinget.Client\Devolutions.Pinget.Client.psd1"),
     [string]$SystemWinget = "winget",
     [string[]]$ReadOnlyCases = @(
         "show-versions",

--- a/scripts/Set-PingetVersion.ps1
+++ b/scripts/Set-PingetVersion.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidatePattern('^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$')]
+    [string]$Version
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+function Set-VersionInFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath,
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern,
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Replacement,
+        [int]$ExpectedMatches = 1
+    )
+
+    $path = Join-Path $repoRoot $RelativePath
+    if (-not (Test-Path -Path $path)) {
+        throw "Version target not found: $RelativePath"
+    }
+
+    $content = [System.IO.File]::ReadAllText($path)
+    $matches = [regex]::Matches($content, $Pattern, [System.Text.RegularExpressions.RegexOptions]::Multiline)
+    if ($matches.Count -ne $ExpectedMatches) {
+        throw "Expected $ExpectedMatches version match(es) in $RelativePath but found $($matches.Count)."
+    }
+
+    $updated = [regex]::Replace(
+        $content,
+        $Pattern,
+        {
+            param($match)
+            & $Replacement $match
+        },
+        [System.Text.RegularExpressions.RegexOptions]::Multiline)
+
+    [System.IO.File]::WriteAllText($path, $updated, [System.Text.UTF8Encoding]::new($false))
+    Write-Host "Updated $RelativePath"
+}
+
+Set-VersionInFile `
+    -RelativePath 'rust\crates\pinget-core\Cargo.toml' `
+    -Pattern '^(version\s*=\s*")[^"]+(")' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-VersionInFile `
+    -RelativePath 'rust\crates\pinget-cli\Cargo.toml' `
+    -Pattern '^(version\s*=\s*")[^"]+(")' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-VersionInFile `
+    -RelativePath 'rust\crates\pinget-cli\Cargo.toml' `
+    -Pattern '(pinget-core\s*=\s*\{\s*version\s*=\s*")[^"]+(")' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-VersionInFile `
+    -RelativePath 'dotnet\src\Devolutions.Pinget.Cli\Program.cs' `
+    -Pattern '^(const string Version\s*=\s*")[^"]+(";)' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-VersionInFile `
+    -RelativePath 'dotnet\src\Devolutions.Pinget.PowerShell.Engine\PowerShellEngineVersion.cs' `
+    -Pattern '^(    public const string Current\s*=\s*")[^"]+(";)' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+$moduleVersion = if ($Version -match '^(\d+\.\d+\.\d+(?:\.\d+)?)') { $Matches[1] } else { $Version }
+Set-VersionInFile `
+    -RelativePath 'dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\ModuleFiles\Devolutions.Pinget.Client.psd1' `
+    -Pattern "^(    ModuleVersion\s*=\s*')[^']+(')" `
+    -Replacement { param($match) "$($match.Groups[1].Value)$moduleVersion$($match.Groups[2].Value)" }


### PR DESCRIPTION
## Summary
- publish the PowerShell module as `Devolutions.Pinget.Client` with a Gallery-ready module layout
- update CI/release/parity workflows to stage, validate, archive, and optionally publish the PowerShell module separately from NuGet libraries
- remove exported cmdlet aliases and add `scripts\Set-PingetVersion.ps1` for synchronized version updates

## Validation
- `dotnet build dotnet\Devolutions.Pinget.slnx -c Release --no-restore`
- staged `Devolutions.Pinget.Client` module and confirmed `AliasCount = 0`
- `pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet\tests\RunTests.ps1')`