### PR TITLE
Make release workflow manual-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  # Keep releases manual-only so default-branch merges do not request approval.
   workflow_dispatch:
     inputs:
       version:

--- a/scripts/Parity-Compare-WingetParity.ps1
+++ b/scripts/Parity-Compare-WingetParity.ps1
@@ -246,7 +246,7 @@ function Get-DotnetSettingsObject {
 
 function Get-PowerShellSettingsObject {
     Import-PingetPowerShellModule
-    return Get-PingetUserSettings -ErrorAction Stop
+    return Get-PingetUserSetting -ErrorAction Stop
 }
 
 function Assert-TestSettingsVisible {
@@ -649,7 +649,7 @@ try {
 
     Write-Section "Settings roundtrip"
     $testSettings = New-TestSettingsHashtable
-    Set-PingetUserSettings -UserSettings $testSettings -ErrorAction Stop | Out-Null
+    Set-PingetUserSetting -UserSettings $testSettings -ErrorAction Stop | Out-Null
     Assert-True -Condition (Test-Path -Path $settingsPath) -Message "PowerShell settings write did not create the packaged settings file."
     Assert-TestSettingsVisible -SettingsObject (Get-RustSettingsObject) -Label "Rust pinget settings export"
     Assert-TestSettingsVisible -SettingsObject (Get-DotnetSettingsObject) -Label "C# pinget settings export"


### PR DESCRIPTION
## Summary
- Remove the `master` push trigger from the release workflow so merges do not automatically request release approval
- Update the parity coherence script to use the exported singular PowerShell user-setting cmdlets

## Validation
- `cargo build -p pinget-cli --manifest-path rust\Cargo.toml`
- `dotnet build dotnet\Devolutions.Pinget.slnx -c Release`
- `pwsh -NoLogo -NoProfile -File (Resolve-Path 'scripts\Build-PowerShellModule.ps1') -NoBuild -OutputRoot dist\powershell-module -Clean`
- Packaged module import and `Get-PingetUserSetting` smoke check
- `pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet\tests\RunTests.ps1')`
