### PR TITLE
Fix release creation without checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -539,7 +539,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ needs.preflight.outputs.tag-name }}" dist/release/*.zip dist/release/*.nupkg dist/release/*.snupkg --generate-notes
+          gh release create "${{ needs.preflight.outputs.tag-name }}" dist/release/*.zip dist/release/*.nupkg dist/release/*.snupkg --generate-notes --repo "${{ github.repository }}"
 
   publish-nuget:
     name: Publish NuGet


### PR DESCRIPTION
## Summary
- Pass the repository explicitly to `gh release create` in the GitHub Release job
- Avoid relying on a checked-out `.git` directory after artifact download

## Validation
- `git diff --check -- .github\workflows\release.yml`