### PR TITLE
Add Rust COM bridge for Windows PowerShell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,6 @@ jobs:
       - name: Run core tests
         run: dotnet test dotnet/src/Devolutions.Pinget.Core.Tests/Devolutions.Pinget.Core.Tests.csproj -c Release --no-build
 
-      - name: Run PowerShell tests
-        shell: pwsh
-        run: pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet/tests/RunTests.ps1')
-
       - name: Build native COM DLLs
         shell: pwsh
         env:
@@ -118,6 +114,10 @@ jobs:
         run: |
           cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target x86_64-pc-windows-msvc
           cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target aarch64-pc-windows-msvc
+
+      - name: Run PowerShell tests
+        shell: pwsh
+        run: pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet/tests/RunTests.ps1')
 
       - name: Validate NuGet packing
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Setup Rust
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal --target x86_64-pc-windows-msvc --target aarch64-pc-windows-msvc
+          rustup default stable
+
       - name: Install Pester
         shell: pwsh
         run: |
@@ -104,6 +110,14 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet/tests/RunTests.ps1')
+
+      - name: Build native COM DLLs
+        shell: pwsh
+        env:
+          RUSTFLAGS: -C target-feature=+crt-static
+        run: |
+          cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target x86_64-pc-windows-msvc
+          cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target aarch64-pc-windows-msvc
 
       - name: Validate NuGet packing
         shell: pwsh

--- a/.github/workflows/parity-test.yml
+++ b/.github/workflows/parity-test.yml
@@ -31,13 +31,21 @@ jobs:
       - name: Setup Rust
         shell: pwsh
         run: |
-          rustup toolchain install stable --profile minimal
+          rustup toolchain install stable --profile minimal --target x86_64-pc-windows-msvc --target aarch64-pc-windows-msvc
           rustup default stable
 
       - name: Build pinget-cli
         shell: pwsh
         run: |
           cargo build -p pinget-cli --manifest-path rust/Cargo.toml
+
+      - name: Build native COM DLLs
+        shell: pwsh
+        env:
+          RUSTFLAGS: -C target-feature=+crt-static
+        run: |
+          cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target x86_64-pc-windows-msvc
+          cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target aarch64-pc-windows-msvc
 
       - name: Build C# CLI and PowerShell module
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,6 +353,12 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Setup Rust
+        shell: pwsh
+        run: |
+          rustup toolchain install stable --profile minimal --target x86_64-pc-windows-msvc --target aarch64-pc-windows-msvc
+          rustup default stable
+
       - name: Install Pester
         shell: pwsh
         run: |
@@ -371,6 +377,14 @@ jobs:
       - name: Run PowerShell tests
         shell: pwsh
         run: pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet/tests/RunTests.ps1')
+
+      - name: Build native COM DLLs
+        shell: pwsh
+        env:
+          RUSTFLAGS: -C target-feature=+crt-static
+        run: |
+          cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target x86_64-pc-windows-msvc
+          cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target aarch64-pc-windows-msvc
 
       - name: Install code signing tools
         shell: pwsh
@@ -430,7 +444,9 @@ jobs:
           $BinaryRoots = @(
             'dotnet/src/Devolutions.Pinget.Core/bin/Release',
             'dotnet/src/Devolutions.Pinget.PowerShell.Engine/bin/Release',
-            'dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/bin/Release'
+            'dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/bin/Release',
+            'rust/target/x86_64-pc-windows-msvc/release',
+            'rust/target/aarch64-pc-windows-msvc/release'
           )
           $Binaries = @(Get-ChildItem -Path $BinaryRoots -Recurse -File -Include '*.dll','*.exe' | Where-Object {
             $_.FullName -like '*\bin\Release\*' -and $_.FullName -notmatch '\\ref\\'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,10 +374,6 @@ jobs:
       - name: Run core tests
         run: dotnet test dotnet/src/Devolutions.Pinget.Core.Tests/Devolutions.Pinget.Core.Tests.csproj -c Release --no-build
 
-      - name: Run PowerShell tests
-        shell: pwsh
-        run: pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet/tests/RunTests.ps1')
-
       - name: Build native COM DLLs
         shell: pwsh
         env:
@@ -385,6 +381,10 @@ jobs:
         run: |
           cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target x86_64-pc-windows-msvc
           cargo build -p pinget-com --manifest-path rust/Cargo.toml --release --target aarch64-pc-windows-msvc
+
+      - name: Run PowerShell tests
+        shell: pwsh
+        run: pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet/tests/RunTests.ps1')
 
       - name: Install code signing tools
         shell: pwsh

--- a/dotnet/Devolutions.Pinget.slnx
+++ b/dotnet/Devolutions.Pinget.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/Devolutions.Pinget.Cli/Devolutions.Pinget.Cli.csproj" />
+    <Project Path="src/Devolutions.Pinget.ComInterop.Net48/Devolutions.Pinget.ComInterop.Net48.csproj" />
     <Project Path="src/Devolutions.Pinget.Core/Devolutions.Pinget.Core.csproj" />
     <Project Path="src/Devolutions.Pinget.PowerShell.Engine/Devolutions.Pinget.PowerShell.Engine.csproj" />
     <Project Path="src/Devolutions.Pinget.PowerShell.Cmdlets/Devolutions.Pinget.PowerShell.Cmdlets.csproj" />

--- a/dotnet/src/Devolutions.Pinget.Cli/Program.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/Program.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Nodes;
 using Devolutions.Pinget.Core;
 using YamlDotNet.Serialization;
 
-const string Version = "0.1.0";
+const string Version = "0.2.0";
 const string UpgradeUnsupportedWarning = "Upgrading packages is not supported on this platform; no changes were made.";
 
 if (args.Length == 1 && (string.Equals(args[0], "--version", StringComparison.OrdinalIgnoreCase) || string.Equals(args[0], "-v", StringComparison.OrdinalIgnoreCase)))

--- a/dotnet/src/Devolutions.Pinget.ComInterop.Net48/Devolutions.Pinget.ComInterop.Net48.csproj
+++ b/dotnet/src/Devolutions.Pinget.ComInterop.Net48/Devolutions.Pinget.ComInterop.Net48.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>true</IsPackable>
+    <AssemblyName>Devolutions.Pinget.ComInterop.Net48</AssemblyName>
+    <RootNamespace>Devolutions.Pinget.ComInterop</RootNamespace>
+    <PackageId>Devolutions.Pinget.ComInterop.Net48</PackageId>
+    <Description>.NET Framework bridge for loading and consuming the registration-free native Pinget COM DLL.</Description>
+  </PropertyGroup>
+</Project>

--- a/dotnet/src/Devolutions.Pinget.ComInterop.Net48/HResult.cs
+++ b/dotnet/src/Devolutions.Pinget.ComInterop.Net48/HResult.cs
@@ -1,0 +1,30 @@
+using System.Runtime.InteropServices;
+
+namespace Devolutions.Pinget.ComInterop
+{
+    internal static class HResult
+    {
+        public const int EPointer = unchecked((int)0x80004003);
+
+        public static void ThrowIfFailed(int hresult)
+        {
+            if (hresult < 0)
+            {
+                Marshal.ThrowExceptionForHR(hresult);
+            }
+        }
+
+        public static void ThrowIfFailed(int hresult, string? message)
+        {
+            if (hresult < 0)
+            {
+                if (!string.IsNullOrWhiteSpace(message))
+                {
+                    throw new COMException(message, hresult);
+                }
+
+                Marshal.ThrowExceptionForHR(hresult);
+            }
+        }
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.ComInterop.Net48/IPackageManagerNative.cs
+++ b/dotnet/src/Devolutions.Pinget.ComInterop.Net48/IPackageManagerNative.cs
@@ -1,0 +1,153 @@
+using System.Runtime.InteropServices;
+
+namespace Devolutions.Pinget.ComInterop
+{
+    [ComImport]
+    [Guid("347FA969-B65E-4282-9E51-2F892E11A322")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IPackageManagerNative
+    {
+        [PreserveSig]
+        int GetVersion([MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int GetDefaultAppRoot([MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int ListSourcesJson([MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int AddSource(
+            [MarshalAs(UnmanagedType.BStr)] string name,
+            [MarshalAs(UnmanagedType.BStr)] string argument,
+            [MarshalAs(UnmanagedType.BStr)] string sourceType,
+            [MarshalAs(UnmanagedType.BStr)] string trustLevel,
+            int explicitSource,
+            int priority);
+
+        [PreserveSig]
+        int RemoveSource([MarshalAs(UnmanagedType.BStr)] string name);
+
+        [PreserveSig]
+        int ResetSource([MarshalAs(UnmanagedType.BStr)] string name, int all);
+
+        [PreserveSig]
+        int EditSourceJson([MarshalAs(UnmanagedType.BStr)] string requestJson);
+
+        [PreserveSig]
+        int UpdateSourcesJson(
+            [MarshalAs(UnmanagedType.BStr)] string sourceName,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int GetUserSettingsJson([MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int SetUserSettingsJson(
+            [MarshalAs(UnmanagedType.BStr)] string settingsJson,
+            int merge,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int TestUserSettingsJson(
+            [MarshalAs(UnmanagedType.BStr)] string expectedJson,
+            int ignoreNotSet,
+            out int matched);
+
+        [PreserveSig]
+        int GetAdminSettingsJson([MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int SetAdminSetting(
+            [MarshalAs(UnmanagedType.BStr)] string name,
+            int enabled);
+
+        [PreserveSig]
+        int ResetAdminSetting(
+            [MarshalAs(UnmanagedType.BStr)] string name,
+            int resetAll);
+
+        [PreserveSig]
+        int EnsureSettingsFiles();
+
+        [PreserveSig]
+        int SearchJson(
+            [MarshalAs(UnmanagedType.BStr)] string queryJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int SearchManifestsJson(
+            [MarshalAs(UnmanagedType.BStr)] string queryJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int ListJson(
+            [MarshalAs(UnmanagedType.BStr)] string queryJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int SearchVersionsJson(
+            [MarshalAs(UnmanagedType.BStr)] string queryJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int ShowVersionsJson(
+            [MarshalAs(UnmanagedType.BStr)] string queryJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int ShowJson(
+            [MarshalAs(UnmanagedType.BStr)] string queryJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int WarmCacheJson(
+            [MarshalAs(UnmanagedType.BStr)] string queryJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int ListPinsJson(
+            [MarshalAs(UnmanagedType.BStr)] string sourceId,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int AddPin(
+            [MarshalAs(UnmanagedType.BStr)] string packageId,
+            [MarshalAs(UnmanagedType.BStr)] string version,
+            [MarshalAs(UnmanagedType.BStr)] string sourceId,
+            [MarshalAs(UnmanagedType.BStr)] string pinType);
+
+        [PreserveSig]
+        int RemovePin(
+            [MarshalAs(UnmanagedType.BStr)] string packageId,
+            [MarshalAs(UnmanagedType.BStr)] string sourceId,
+            out int removed);
+
+        [PreserveSig]
+        int ResetPins([MarshalAs(UnmanagedType.BStr)] string sourceId);
+
+        [PreserveSig]
+        int DownloadInstallerJson(
+            [MarshalAs(UnmanagedType.BStr)] string requestJson,
+            [MarshalAs(UnmanagedType.BStr)] string downloadDirectory,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int InstallJson(
+            [MarshalAs(UnmanagedType.BStr)] string requestJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int UninstallJson(
+            [MarshalAs(UnmanagedType.BStr)] string requestJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int RepairJson(
+            [MarshalAs(UnmanagedType.BStr)] string requestJson,
+            [MarshalAs(UnmanagedType.BStr)] out string value);
+
+        [PreserveSig]
+        int GetLastError([MarshalAs(UnmanagedType.BStr)] out string value);
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.ComInterop.Net48/NativeMethods.cs
+++ b/dotnet/src/Devolutions.Pinget.ComInterop.Net48/NativeMethods.cs
@@ -1,0 +1,63 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace Devolutions.Pinget.ComInterop
+{
+    internal static class NativeMethods
+    {
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr LoadLibraryW(string lpFileName);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
+        private static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool FreeLibrary(IntPtr hModule);
+
+        public static NativeLibraryHandle LoadLibrary(string path)
+        {
+            var handle = LoadLibraryW(path);
+            if (handle == IntPtr.Zero)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to load native Pinget COM library '{path}'.");
+            }
+
+            return new NativeLibraryHandle(handle);
+        }
+
+        public static TDelegate GetRequiredExport<TDelegate>(NativeLibraryHandle library, string name)
+            where TDelegate : class
+        {
+            var address = GetProcAddress(library.DangerousGetHandle(), name);
+            if (address == IntPtr.Zero)
+            {
+                throw new MissingMethodException($"Native Pinget COM library does not export '{name}'.");
+            }
+
+            return (TDelegate)(object)Marshal.GetDelegateForFunctionPointer(address, typeof(TDelegate));
+        }
+
+        internal sealed class NativeLibraryHandle : SafeHandle
+        {
+            public NativeLibraryHandle()
+                : base(IntPtr.Zero, true)
+            {
+            }
+
+            public NativeLibraryHandle(IntPtr handle)
+                : this()
+            {
+                SetHandle(handle);
+            }
+
+            public override bool IsInvalid => handle == IntPtr.Zero;
+
+            protected override bool ReleaseHandle()
+            {
+                return FreeLibrary(handle);
+            }
+        }
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.ComInterop.Net48/NativePingetComLibrary.cs
+++ b/dotnet/src/Devolutions.Pinget.ComInterop.Net48/NativePingetComLibrary.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Devolutions.Pinget.ComInterop
+{
+    public sealed class NativePingetComLibrary : IDisposable
+    {
+        private const string NativeFileName = "pinget-com.dll";
+        private const string LegacyNativeFileName = "pinget_com.dll";
+
+        private readonly NativeMethods.NativeLibraryHandle _library;
+        private readonly PingetCreatePackageManagerDelegate _createPackageManager;
+        private bool _disposed;
+
+        private NativePingetComLibrary(NativeMethods.NativeLibraryHandle library)
+        {
+            _library = library;
+            _createPackageManager = NativeMethods.GetRequiredExport<PingetCreatePackageManagerDelegate>(
+                _library,
+                "PingetCreatePackageManager");
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate int PingetCreatePackageManagerDelegate(ref Guid riid, out IntPtr instance);
+
+        public static NativePingetComLibrary LoadFromDefaultLocation()
+        {
+            return LoadFromBaseDirectory(GetAssemblyDirectory());
+        }
+
+        public static NativePingetComLibrary LoadFromBaseDirectory(string baseDirectory)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new PlatformNotSupportedException("The Pinget COM bridge is Windows-only.");
+            }
+
+            foreach (var candidate in GetCandidatePaths(baseDirectory))
+            {
+                if (File.Exists(candidate))
+                {
+                    return new NativePingetComLibrary(NativeMethods.LoadLibrary(candidate));
+                }
+            }
+
+            throw new FileNotFoundException(
+                $"Could not find '{NativeFileName}' relative to '{baseDirectory}'.",
+                Path.Combine(baseDirectory, NativeFileName));
+        }
+
+        public PingetPackageManager CreatePackageManager()
+        {
+            ThrowIfDisposed();
+
+            var iid = PingetPackageManager.NativeInterfaceId;
+            var hr = _createPackageManager(ref iid, out var instance);
+            HResult.ThrowIfFailed(hr);
+
+            if (instance == IntPtr.Zero)
+            {
+                throw new COMException("Native Pinget COM library returned a null package manager pointer.", HResult.EPointer);
+            }
+
+            try
+            {
+                var native = (IPackageManagerNative)Marshal.GetTypedObjectForIUnknown(instance, typeof(IPackageManagerNative));
+                return new PingetPackageManager(native);
+            }
+            finally
+            {
+                Marshal.Release(instance);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _library.Dispose();
+            _disposed = true;
+        }
+
+        private static string GetAssemblyDirectory()
+        {
+            var location = typeof(NativePingetComLibrary).Assembly.Location;
+            if (string.IsNullOrWhiteSpace(location))
+            {
+                location = Assembly.GetExecutingAssembly().Location;
+            }
+
+            return Path.GetDirectoryName(location) ?? AppDomain.CurrentDomain.BaseDirectory;
+        }
+
+        private static string[] GetCandidatePaths(string baseDirectory)
+        {
+            var architectureDirectory = GetWindowsRuntimeIdentifier();
+            return new[]
+            {
+                Path.Combine(baseDirectory, "runtimes", architectureDirectory, "native", NativeFileName),
+                Path.Combine(baseDirectory, "runtimes", architectureDirectory, "native", LegacyNativeFileName),
+                Path.Combine(baseDirectory, NativeFileName),
+                Path.Combine(baseDirectory, LegacyNativeFileName),
+                Path.Combine(baseDirectory, GetArchitectureDirectoryName(), NativeFileName),
+                Path.Combine(baseDirectory, GetArchitectureDirectoryName(), LegacyNativeFileName),
+            };
+        }
+
+        private static string GetWindowsRuntimeIdentifier()
+        {
+            switch (RuntimeInformation.ProcessArchitecture)
+            {
+                case Architecture.X64:
+                    return "win-x64";
+                case Architecture.Arm64:
+                    return "win-arm64";
+                default:
+                    throw new PlatformNotSupportedException(
+                        $"The Pinget COM bridge is only packaged for x64 and ARM64 Windows processes; current process architecture is {RuntimeInformation.ProcessArchitecture}.");
+            }
+        }
+
+        private static string GetArchitectureDirectoryName()
+        {
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : "x64";
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(NativePingetComLibrary));
+            }
+        }
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.ComInterop.Net48/PingetPackageManager.cs
+++ b/dotnet/src/Devolutions.Pinget.ComInterop.Net48/PingetPackageManager.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Devolutions.Pinget.ComInterop
+{
+    public sealed class PingetPackageManager : IDisposable
+    {
+        internal static readonly Guid NativeInterfaceId = new Guid("347FA969-B65E-4282-9E51-2F892E11A322");
+
+        private IPackageManagerNative? _native;
+
+        internal PingetPackageManager(IPackageManagerNative native)
+        {
+            _native = native ?? throw new ArgumentNullException(nameof(native));
+        }
+
+        public string GetVersion()
+        {
+            var native = GetNative();
+            var hr = native.GetVersion(out var value);
+            ThrowIfFailed(native, hr);
+            return value;
+        }
+
+        public string GetDefaultAppRoot()
+        {
+            var native = GetNative();
+            var hr = native.GetDefaultAppRoot(out var value);
+            ThrowIfFailed(native, hr);
+            return value;
+        }
+
+        public string ListSourcesJson()
+        {
+            var native = GetNative();
+            var hr = native.ListSourcesJson(out var value);
+            ThrowIfFailed(native, hr);
+            return value;
+        }
+
+        public void AddSource(string name, string argument, string? sourceType, string? trustLevel, bool explicitSource, int priority)
+        {
+            var native = GetNative();
+            var hr = native.AddSource(
+                name,
+                argument,
+                sourceType ?? string.Empty,
+                trustLevel ?? string.Empty,
+                explicitSource ? 1 : 0,
+                priority);
+            ThrowIfFailed(native, hr);
+        }
+
+        public void RemoveSource(string name)
+        {
+            var native = GetNative();
+            var hr = native.RemoveSource(name);
+            ThrowIfFailed(native, hr);
+        }
+
+        public void ResetSource(string? name, bool all)
+        {
+            var native = GetNative();
+            var hr = native.ResetSource(name ?? string.Empty, all ? 1 : 0);
+            ThrowIfFailed(native, hr);
+        }
+
+        public void EditSourceJson(string requestJson)
+        {
+            var native = GetNative();
+            var hr = native.EditSourceJson(requestJson);
+            ThrowIfFailed(native, hr);
+        }
+
+        public string UpdateSourcesJson(string? sourceName) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.UpdateSourcesJson(sourceName ?? string.Empty, out value));
+
+        public string GetUserSettingsJson() =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.GetUserSettingsJson(out value));
+
+        public string SetUserSettingsJson(string settingsJson, bool merge) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.SetUserSettingsJson(settingsJson, merge ? 1 : 0, out value));
+
+        public bool TestUserSettingsJson(string expectedJson, bool ignoreNotSet)
+        {
+            var native = GetNative();
+            var hr = native.TestUserSettingsJson(expectedJson, ignoreNotSet ? 1 : 0, out var matched);
+            ThrowIfFailed(native, hr);
+            return matched != 0;
+        }
+
+        public string GetAdminSettingsJson() =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.GetAdminSettingsJson(out value));
+
+        public void SetAdminSetting(string name, bool enabled)
+        {
+            var native = GetNative();
+            var hr = native.SetAdminSetting(name, enabled ? 1 : 0);
+            ThrowIfFailed(native, hr);
+        }
+
+        public void ResetAdminSetting(string? name, bool resetAll)
+        {
+            var native = GetNative();
+            var hr = native.ResetAdminSetting(name ?? string.Empty, resetAll ? 1 : 0);
+            ThrowIfFailed(native, hr);
+        }
+
+        public void EnsureSettingsFiles()
+        {
+            var native = GetNative();
+            var hr = native.EnsureSettingsFiles();
+            ThrowIfFailed(native, hr);
+        }
+
+        public string SearchJson(string queryJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.SearchJson(queryJson, out value));
+
+        public string SearchManifestsJson(string queryJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.SearchManifestsJson(queryJson, out value));
+
+        public string ListJson(string queryJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.ListJson(queryJson, out value));
+
+        public string SearchVersionsJson(string queryJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.SearchVersionsJson(queryJson, out value));
+
+        public string ShowVersionsJson(string queryJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.ShowVersionsJson(queryJson, out value));
+
+        public string ShowJson(string queryJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.ShowJson(queryJson, out value));
+
+        public string WarmCacheJson(string queryJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.WarmCacheJson(queryJson, out value));
+
+        public string ListPinsJson(string? sourceId) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.ListPinsJson(sourceId ?? string.Empty, out value));
+
+        public void AddPin(string packageId, string version, string sourceId, string pinType)
+        {
+            var native = GetNative();
+            var hr = native.AddPin(packageId, version, sourceId, pinType);
+            ThrowIfFailed(native, hr);
+        }
+
+        public bool RemovePin(string packageId, string? sourceId)
+        {
+            var native = GetNative();
+            var hr = native.RemovePin(packageId, sourceId ?? string.Empty, out var removed);
+            ThrowIfFailed(native, hr);
+            return removed != 0;
+        }
+
+        public void ResetPins(string? sourceId)
+        {
+            var native = GetNative();
+            var hr = native.ResetPins(sourceId ?? string.Empty);
+            ThrowIfFailed(native, hr);
+        }
+
+        public string DownloadInstallerJson(string requestJson, string downloadDirectory) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.DownloadInstallerJson(requestJson, downloadDirectory, out value));
+
+        public string InstallJson(string requestJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.InstallJson(requestJson, out value));
+
+        public string UninstallJson(string requestJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.UninstallJson(requestJson, out value));
+
+        public string RepairJson(string requestJson) =>
+            InvokeJson((IPackageManagerNative native, out string value) => native.RepairJson(requestJson, out value));
+
+        public void Dispose()
+        {
+            var native = _native;
+            if (native is null)
+            {
+                return;
+            }
+
+            Marshal.FinalReleaseComObject(native);
+            _native = null;
+        }
+
+        private IPackageManagerNative GetNative()
+        {
+            return _native ?? throw new ObjectDisposedException(nameof(PingetPackageManager));
+        }
+
+        private string InvokeJson(JsonInvoker invoker)
+        {
+            var native = GetNative();
+            var hr = invoker(native, out var value);
+            ThrowIfFailed(native, hr);
+            return value;
+        }
+
+        private delegate int JsonInvoker(IPackageManagerNative native, out string value);
+
+        private static void ThrowIfFailed(IPackageManagerNative native, int hresult)
+        {
+            if (hresult >= 0)
+            {
+                return;
+            }
+
+            string? message = null;
+            try
+            {
+                if (native.GetLastError(out var value) >= 0)
+                {
+                    message = value;
+                }
+            }
+            catch (COMException)
+            {
+            }
+
+            HResult.ThrowIfFailed(hresult, message);
+        }
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
@@ -933,6 +933,31 @@ public class RepositoryParityTests
     }
 
     [Fact]
+    public void CreateDependencyInstallRequest_IsSilentAndNotForced()
+    {
+        var result = Repository.CreateDependencyInstallRequest(
+            "Microsoft.VCRedist.2015+.x64",
+            new InstallRequest
+            {
+                Query = new PackageQuery { Source = "winget" },
+                Mode = InstallerMode.SilentWithProgress,
+                Force = true,
+                AcceptPackageAgreements = true,
+                IgnoreSecurityHash = true,
+                DependencySource = "dependencies",
+            });
+
+        Assert.Equal("Microsoft.VCRedist.2015+.x64", result.Query.Id);
+        Assert.Equal("dependencies", result.Query.Source);
+        Assert.True(result.Query.Exact);
+        Assert.Equal(InstallerMode.Silent, result.Mode);
+        Assert.False(result.Force);
+        Assert.True(result.NoUpgrade);
+        Assert.True(result.AcceptPackageAgreements);
+        Assert.True(result.IgnoreSecurityHash);
+    }
+
+    [Fact]
     public void CreateInstallNoOpResult_SkipsReinstallWhenAlreadyCurrent()
     {
         var result = Repository.CreateInstallNoOpResult(

--- a/dotnet/src/Devolutions.Pinget.Core/Repository.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Repository.cs
@@ -737,24 +737,26 @@ public class Repository : IDisposable
 
         foreach (var dependencyId in dependencies)
         {
-            Install(new InstallRequest
-            {
-                Query = new PackageQuery
-                {
-                    Id = dependencyId,
-                    Source = request.DependencySource ?? request.Query.Source,
-                    Exact = true,
-                },
-                Mode = request.Mode,
-                SkipDependencies = false,
-                DependenciesOnly = false,
-                AcceptPackageAgreements = request.AcceptPackageAgreements,
-                Force = request.Force,
-                IgnoreSecurityHash = request.IgnoreSecurityHash,
-                DependencySource = request.DependencySource,
-            });
+            Install(CreateDependencyInstallRequest(dependencyId, request));
         }
     }
+
+    internal static InstallRequest CreateDependencyInstallRequest(string dependencyId, InstallRequest request) => new()
+    {
+        Query = new PackageQuery
+        {
+            Id = dependencyId,
+            Source = request.DependencySource ?? request.Query.Source,
+            Exact = true,
+        },
+        Mode = request.Mode == InstallerMode.Interactive ? InstallerMode.Interactive : InstallerMode.Silent,
+        SkipDependencies = false,
+        DependenciesOnly = false,
+        AcceptPackageAgreements = request.AcceptPackageAgreements,
+        NoUpgrade = true,
+        IgnoreSecurityHash = request.IgnoreSecurityHash,
+        DependencySource = request.DependencySource,
+    };
 
     internal static ListQuery CreateRepairListQuery(RepairRequest request) => new()
     {

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/ExportPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/ExportPackageCmdlet.cs
@@ -23,7 +23,7 @@ public sealed class ExportPackageCmdlet : InstallerSelectionCmdlet
 
     protected override void ProcessRecord()
     {
-        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(' ', Query ?? []);
+        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(" ", Query ?? []);
         if (!ShouldProcess(target, "Export package"))
             return;
 

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/InstallPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/InstallPackageCmdlet.cs
@@ -11,7 +11,7 @@ public sealed class InstallPackageCmdlet : InstallCmdlet
 {
     protected override void ProcessRecord()
     {
-        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(' ', Query ?? []);
+        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(" ", Query ?? []);
         if (!ShouldProcess(target, "Install package"))
             return;
 

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/RepairPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/RepairPackageCmdlet.cs
@@ -23,7 +23,7 @@ public sealed class RepairPackageCmdlet : PackageCmdlet
 
     protected override void ProcessRecord()
     {
-        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(' ', Query ?? []);
+        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(" ", Query ?? []);
         if (!ShouldProcess(target, "Repair package"))
             return;
 

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/UninstallPackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/UninstallPackageCmdlet.cs
@@ -20,7 +20,7 @@ public sealed class UninstallPackageCmdlet : PackageCmdlet
 
     protected override void ProcessRecord()
     {
-        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(' ', Query ?? []);
+        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(" ", Query ?? []);
         if (!ShouldProcess(target, "Uninstall package"))
             return;
 

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/UpdatePackageCmdlet.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Cmdlets/UpdatePackageCmdlet.cs
@@ -14,7 +14,7 @@ public sealed class UpdatePackageCmdlet : InstallCmdlet
 
     protected override void ProcessRecord()
     {
-        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(' ', Query ?? []);
+        var target = PSCatalogPackage?.Id ?? Id ?? Name ?? string.Join(" ", Query ?? []);
         if (!ShouldProcess(target, "Update package"))
             return;
 

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Devolutions.Pinget.PowerShell.Cmdlets.csproj
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/Devolutions.Pinget.PowerShell.Cmdlets.csproj
@@ -3,14 +3,21 @@
     <ProjectReference Include="..\Devolutions.Pinget.PowerShell.Engine\Devolutions.Pinget.PowerShell.Engine.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
     <PackageReference Include="PowerShellStandard.Library" Version="7.0.0-preview.1" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" PrivateAssets="all" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
     <AssemblyName>Devolutions.Pinget.PowerShell.Cmdlets</AssemblyName>

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
@@ -1,13 +1,13 @@
 @{
-    RootModule = 'Devolutions.Pinget.PowerShell.Cmdlets.dll'
+    RootModule = 'Devolutions.Pinget.Client.psm1'
     ModuleVersion = '0.1.0'
-    CompatiblePSEditions = @('Core')
+    CompatiblePSEditions = @('Desktop', 'Core')
     GUID = 'c6d1b5f2-5ccd-4771-9480-25caad7c58bd'
     Author = 'Devolutions'
     CompanyName = 'Devolutions'
     Copyright = '(c) Devolutions. All rights reserved.'
-    Description = 'PowerShell 7 winget-compatible pinget module.'
-    PowerShellVersion = '7.4.0'
+    Description = 'WinGet-compatible Pinget module for Windows PowerShell and PowerShell 7.'
+    PowerShellVersion = '5.1'
 
     FunctionsToExport = @()
 
@@ -42,6 +42,7 @@
         PSData = @{
             Tags = @(
                 'PSEdition_Core'
+                'PSEdition_Desktop'
                 'WindowsPackageManager'
                 'WinGet'
                 'Pinget'

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Devolutions.Pinget.Client.psm1'
-    ModuleVersion = '0.1.0'
+    ModuleVersion = '0.2.0'
     CompatiblePSEditions = @('Desktop', 'Core')
     GUID = 'c6d1b5f2-5ccd-4771-9480-25caad7c58bd'
     Author = 'Devolutions'

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psm1
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psm1
@@ -1,0 +1,43 @@
+Set-StrictMode -Version Latest
+
+$edition = $PSVersionTable.PSEdition
+if ([string]::IsNullOrWhiteSpace($edition)) {
+    $edition = 'Desktop'
+}
+
+if ($edition -eq 'Desktop') {
+    $implementationRoot = Join-Path $PSScriptRoot 'Desktop\net48'
+}
+elseif ($edition -eq 'Core') {
+    $coreRoot = Join-Path $PSScriptRoot 'Core'
+    $preferredFrameworks = @('net10.0', 'net8.0')
+    $implementationRoot = $null
+    foreach ($framework in $preferredFrameworks) {
+        $candidate = Join-Path $coreRoot $framework
+        if (Test-Path -LiteralPath (Join-Path $candidate 'Devolutions.Pinget.PowerShell.Cmdlets.dll')) {
+            $implementationRoot = $candidate
+            break
+        }
+    }
+
+    if ($null -eq $implementationRoot -and (Test-Path -LiteralPath $coreRoot)) {
+        $implementationRoot = Get-ChildItem -LiteralPath $coreRoot -Directory |
+            Sort-Object -Property Name -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+}
+else {
+    throw "Unsupported PowerShell edition '$edition'."
+}
+
+if ([string]::IsNullOrWhiteSpace($implementationRoot)) {
+    throw "No Pinget implementation folder was found for PowerShell edition '$edition'."
+}
+
+$binaryModule = Join-Path $implementationRoot 'Devolutions.Pinget.PowerShell.Cmdlets.dll'
+if (-not (Test-Path -LiteralPath $binaryModule)) {
+    throw "Pinget binary module not found: $binaryModule"
+}
+
+Import-Module -Name $binaryModule -ErrorAction Stop
+Export-ModuleMember -Cmdlet * -Function * -Alias *

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Engine/Devolutions.Pinget.PowerShell.Engine.csproj
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Engine/Devolutions.Pinget.PowerShell.Engine.csproj
@@ -1,12 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
     <ProjectReference Include="..\Devolutions.Pinget.Core\Devolutions.Pinget.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <ProjectReference Include="..\Devolutions.Pinget.ComInterop.Net48\Devolutions.Pinget.ComInterop.Net48.csproj" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <Compile Remove="PingetClient.cs" />
+  </ItemGroup>
+
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
     <IsPackable>true</IsPackable>
     <AssemblyName>Devolutions.Pinget.PowerShell.Engine</AssemblyName>
     <RootNamespace>Devolutions.Pinget.PowerShell.Engine</RootNamespace>

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Engine/Net48CompilerSupport.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Engine/Net48CompilerSupport.cs
@@ -1,0 +1,38 @@
+#if NET48
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.All, Inherited = false)]
+    internal sealed class RequiredMemberAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+            FeatureName = featureName;
+        }
+
+        public string FeatureName { get; }
+
+        public bool IsOptional { get; init; }
+
+        public const string RefStructs = nameof(RefStructs);
+
+        public const string RequiredMembers = nameof(RequiredMembers);
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    internal sealed class SetsRequiredMembersAttribute : Attribute
+    {
+    }
+}
+#endif

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Engine/PingetClient.Net48.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Engine/PingetClient.Net48.cs
@@ -1,0 +1,781 @@
+#if NET48
+using System.Collections;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Devolutions.Pinget.ComInterop;
+using Devolutions.Pinget.PowerShell.Engine.PSObjects;
+
+namespace Devolutions.Pinget.PowerShell.Engine;
+
+public sealed class PingetClient : IDisposable
+{
+    private readonly NativePingetComLibrary _library;
+    private readonly PingetPackageManager _packageManager;
+
+    private PingetClient(NativePingetComLibrary library, PingetPackageManager packageManager)
+    {
+        _library = library;
+        _packageManager = packageManager;
+    }
+
+    public static PingetClient Open(object? options = null)
+    {
+        if (options is not null)
+            throw new NotSupportedException("Windows PowerShell uses the native Pinget COM bridge and does not accept managed repository options.");
+
+        var library = NativePingetComLibrary.LoadFromDefaultLocation();
+        try
+        {
+            return new PingetClient(library, library.CreatePackageManager());
+        }
+        catch
+        {
+            library.Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        _packageManager.Dispose();
+        _library.Dispose();
+    }
+
+    public string GetVersion() => _packageManager.GetVersion();
+
+    public CollectionResult<PSSourceResult> GetSources(string? name = null)
+    {
+        var sourceArray = JsonNode.Parse(_packageManager.ListSourcesJson()) as JsonArray
+            ?? throw new InvalidOperationException("The native Pinget COM bridge returned invalid source data.");
+
+        var sources = sourceArray
+            .OfType<JsonObject>()
+            .Select(ToSourceResult)
+            .Where(source => string.IsNullOrWhiteSpace(name) || string.Equals(source.Name, name, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(name) && sources.Count == 0)
+            throw new InvalidOperationException($"Source '{name}' not found.");
+
+        return new CollectionResult<PSSourceResult>(sources, Array.Empty<string>());
+    }
+
+    public void AddSource(string name, string argument, string? type, PSSourceTrustLevel trustLevel, bool explicitSource, int priority)
+    {
+        _packageManager.AddSource(
+            name,
+            argument,
+            string.IsNullOrWhiteSpace(type) ? "Microsoft.Rest" : type,
+            trustLevel == PSSourceTrustLevel.Default ? "None" : trustLevel.ToString(),
+            explicitSource,
+            priority);
+    }
+
+    public void RemoveSource(string name) => _packageManager.RemoveSource(name);
+
+    public void ResetSource(string? name, bool all) => _packageManager.ResetSource(name, all);
+
+    public CollectionResult<PSFoundCatalogPackage> FindPackages(
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        string? tag,
+        string? command,
+        uint count,
+        PSPackageFieldMatchOption matchOption)
+    {
+        var response = RequiredObject(_packageManager.SearchJson(ToJsonString(BuildPackageQuery(id, name, moniker, source, query, tag, command, count, matchOption))));
+        var items = RequiredArray(response, "matches")
+            .OfType<JsonObject>()
+            .Select(match => new PSFoundCatalogPackage(
+                RequiredString(match, "id"),
+                RequiredString(match, "name"),
+                RequiredString(match, "source_name"),
+                OptionalString(match, "moniker"),
+                OptionalString(match, "version"),
+                OptionalString(match, "match_criteria")))
+            .ToList();
+
+        return new CollectionResult<PSFoundCatalogPackage>(items, WarningsFrom(response), Bool(response, "truncated"));
+    }
+
+    public CollectionResult<PSInstalledCatalogPackage> GetInstalledPackages(
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        string? tag,
+        string? command,
+        uint count,
+        PSPackageFieldMatchOption matchOption)
+    {
+        var response = RequiredObject(_packageManager.ListJson(ToJsonString(BuildListQuery(id, name, moniker, source, query, tag, command, count, matchOption))));
+        var items = RequiredArray(response, "matches")
+            .OfType<JsonObject>()
+            .Select(match => new PSInstalledCatalogPackage(
+                RequiredString(match, "id"),
+                RequiredString(match, "name"),
+                OptionalString(match, "source_name") ?? string.Empty,
+                null,
+                RequiredString(match, "installed_version"),
+                OptionalString(match, "available_version") is { } availableVersion ? new[] { availableVersion } : Array.Empty<string>(),
+                OptionalString(match, "publisher"),
+                OptionalString(match, "scope"),
+                StringArray(match, "package_family_names"),
+                StringArray(match, "product_codes")))
+            .ToList();
+
+        return new CollectionResult<PSInstalledCatalogPackage>(items, WarningsFrom(response), Bool(response, "truncated"));
+    }
+
+    public CommandResult<PSDownloadResult> DownloadPackage(
+        PSCatalogPackage? inputObject,
+        string? version,
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        bool allowHashMismatch,
+        bool skipDependencies,
+        string? locale,
+        PSPackageInstallScope scope,
+        PSProcessorArchitecture architecture,
+        PSPackageInstallerType installerType,
+        string? downloadDirectory,
+        bool skipMicrosoftStoreLicense,
+        PSWindowsPlatform platform,
+        string? targetOsVersion)
+    {
+        var warnings = new List<string>();
+        AddDownloadCompatibilityWarnings(warnings, skipDependencies, skipMicrosoftStoreLicense);
+        var queryObject = BuildPackageQuery(
+            id ?? inputObject?.Id,
+            name ?? inputObject?.Name,
+            moniker ?? inputObject?.Moniker,
+            source ?? inputObject?.Source,
+            query,
+            null,
+            null,
+            0,
+            PSPackageFieldMatchOption.EqualsCaseInsensitive);
+        SetIfNotNull(queryObject, "version", version ?? GetCatalogVersion(inputObject));
+        SetIfNotNull(queryObject, "locale", locale);
+        SetIfNotNull(queryObject, "installer_architecture", architecture == PSProcessorArchitecture.Default ? null : architecture.ToString());
+        SetIfNotNull(queryObject, "installer_type", installerType == PSPackageInstallerType.Default ? null : installerType.ToString());
+        SetIfNotNull(queryObject, "install_scope", scope == PSPackageInstallScope.Any ? null : scope.ToString());
+        SetIfNotNull(queryObject, "platform", ToInstallerPlatform(platform));
+        SetIfNotNull(queryObject, "os_version", Normalize(targetOsVersion));
+
+        var request = new JsonObject
+        {
+            ["query"] = queryObject,
+            ["skip_dependencies"] = skipDependencies,
+            ["ignore_security_hash"] = allowHashMismatch,
+        };
+        var outputDirectory = string.IsNullOrWhiteSpace(downloadDirectory)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads")
+            : downloadDirectory!;
+
+        var response = RequiredObject(_packageManager.DownloadInstallerJson(ToJsonString(request), outputDirectory));
+        var manifest = RequiredObject(response, "manifest");
+        var installerPath = RequiredString(response, "installer_path");
+        return new CommandResult<PSDownloadResult>(
+            new PSDownloadResult
+            {
+                Id = RequiredString(manifest, "id"),
+                Name = RequiredString(manifest, "name"),
+                Source = OptionalString(queryObject, "source") ?? inputObject?.Source ?? string.Empty,
+                CorrelationData = installerPath,
+                Status = "Ok",
+                Version = RequiredString(manifest, "version"),
+                DownloadDirectory = outputDirectory,
+                DownloadedInstallerPath = installerPath,
+            },
+            warnings);
+    }
+
+    public JsonObject GetUserSettings() => RequiredObject(_packageManager.GetUserSettingsJson());
+
+    public JsonObject SetUserSettings(JsonObject userSettings, bool merge) =>
+        RequiredObject(_packageManager.SetUserSettingsJson(ToJsonString(userSettings), merge));
+
+    public bool TestUserSettings(JsonObject expected, bool ignoreNotSet) =>
+        _packageManager.TestUserSettingsJson(ToJsonString(expected), ignoreNotSet);
+
+    public JsonObject GetAdminSettings() => RequiredObject(_packageManager.GetAdminSettingsJson());
+
+    public void SetAdminSetting(string name, bool enabled) => _packageManager.SetAdminSetting(name, enabled);
+
+    public void AssertPackageManager(string? version, bool latest, bool includePrerelease)
+    {
+        if (!string.IsNullOrWhiteSpace(version) &&
+            !string.Equals(version, GetVersion(), StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Requested version '{version}' does not match Pinget version '{GetVersion()}'.");
+        }
+
+        _ = _packageManager.GetDefaultAppRoot();
+        _ = _packageManager.ListSourcesJson();
+        _ = _packageManager.GetAdminSettingsJson();
+        _ = _packageManager.GetUserSettingsJson();
+    }
+
+    public CommandResult<int> RepairPackageManager(string? version, bool latest, bool includePrerelease, bool allUsers, bool force)
+    {
+        var warnings = new List<string>();
+        if (!string.IsNullOrWhiteSpace(version) &&
+            !string.Equals(version, GetVersion(), StringComparison.OrdinalIgnoreCase))
+            warnings.Add($"Requested version '{version}' is not available; repaired current Pinget version '{GetVersion()}' instead.");
+        if (latest)
+            warnings.Add("Latest is accepted for compatibility but Pinget repairs the current local build.");
+        if (includePrerelease)
+            warnings.Add("IncludePrerelease is accepted for compatibility but Pinget repairs the current local build.");
+        if (allUsers)
+            warnings.Add("AllUsers is accepted for compatibility but Pinget repairs the current user's app root.");
+        if (force)
+            warnings.Add("Force is accepted for compatibility but Pinget repair does not require process shutdown today.");
+
+        _packageManager.EnsureSettingsFiles();
+        AssertPackageManager(null, false, false);
+        return new CommandResult<int>(0, warnings);
+    }
+
+    public CommandResult<PSInstallResult> InstallPackage(
+        PSCatalogPackage? inputObject,
+        string? version,
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        bool allowHashMismatch,
+        string? overrideArguments,
+        string? custom,
+        string? location,
+        string? log,
+        bool force,
+        IDictionary? header,
+        bool skipDependencies,
+        string? locale,
+        PSPackageInstallScope scope,
+        PSProcessorArchitecture architecture,
+        PSPackageInstallMode mode,
+        PSPackageInstallerType installerType)
+    {
+        var warnings = HeaderWarnings(header);
+        var request = BuildInstallRequest(
+            inputObject,
+            version,
+            id,
+            name,
+            moniker,
+            source,
+            query,
+            allowHashMismatch,
+            overrideArguments,
+            custom,
+            location,
+            log,
+            force,
+            skipDependencies,
+            locale,
+            scope,
+            architecture,
+            mode,
+            installerType);
+
+        var result = RequiredObject(_packageManager.InstallJson(ToJsonString(request)));
+        warnings.AddRange(WarningsFrom(result));
+        return new CommandResult<PSInstallResult>(ToPsInstallResult(result, request, inputObject), warnings);
+    }
+
+    public CommandResult<PSUninstallResult> UninstallPackage(
+        PSCatalogPackage? inputObject,
+        string? version,
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        bool force,
+        string? log,
+        PSPackageUninstallMode mode)
+    {
+        var request = new JsonObject
+        {
+            ["query"] = BuildPackageQuery(
+                id ?? inputObject?.Id,
+                name ?? inputObject?.Name,
+                moniker ?? inputObject?.Moniker,
+                source ?? inputObject?.Source,
+                query,
+                null,
+                null,
+                0,
+                PSPackageFieldMatchOption.EqualsCaseInsensitive),
+            ["force"] = force,
+            ["mode"] = ToInstallerMode(mode),
+        };
+        SetIfNotNull(request, "log_path", Normalize(log));
+        SetIfNotNull((JsonObject)request["query"]!, "version", version ?? GetCatalogVersion(inputObject));
+
+        var result = RequiredObject(_packageManager.UninstallJson(ToJsonString(request)));
+        return new CommandResult<PSUninstallResult>(ToPsUninstallResult(result, request, inputObject), WarningsFrom(result));
+    }
+
+    public CollectionResult<PSInstallResult> UpdatePackages(
+        PSCatalogPackage? inputObject,
+        string? version,
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        bool allowHashMismatch,
+        string? overrideArguments,
+        string? custom,
+        string? location,
+        string? log,
+        bool force,
+        IDictionary? header,
+        bool skipDependencies,
+        string? locale,
+        PSPackageInstallScope scope,
+        PSProcessorArchitecture architecture,
+        PSPackageInstallMode mode,
+        PSPackageInstallerType installerType,
+        bool includeUnknown)
+    {
+        var warnings = HeaderWarnings(header);
+        var listQuery = new JsonObject
+        {
+            ["id"] = Normalize(id ?? inputObject?.Id),
+            ["name"] = Normalize(name ?? inputObject?.Name),
+            ["moniker"] = Normalize(moniker ?? inputObject?.Moniker),
+            ["source"] = Normalize(source ?? inputObject?.Source),
+            ["query"] = JoinQuery(query),
+            ["version"] = Normalize(version),
+            ["upgrade_only"] = true,
+            ["include_unknown"] = includeUnknown,
+            ["exact"] = true,
+        };
+
+        var matches = RequiredObject(_packageManager.ListJson(ToJsonString(listQuery)));
+        warnings.AddRange(WarningsFrom(matches));
+        var results = new List<PSInstallResult>();
+        foreach (var match in RequiredArray(matches, "matches").OfType<JsonObject>())
+        {
+            var matchSource = OptionalString(match, "source_name");
+            var request = BuildInstallRequest(
+                null,
+                Normalize(version) ?? OptionalString(match, "available_version"),
+                RequiredString(match, "id"),
+                null,
+                null,
+                matchSource,
+                null,
+                allowHashMismatch,
+                overrideArguments,
+                custom,
+                location,
+                log,
+                force,
+                skipDependencies,
+                locale,
+                scope,
+                architecture,
+                mode,
+                installerType);
+            var result = RequiredObject(_packageManager.InstallJson(ToJsonString(request)));
+            warnings.AddRange(WarningsFrom(result));
+            results.Add(ToPsInstallResult(result, request, new PSInstalledCatalogPackage(
+                RequiredString(match, "id"),
+                RequiredString(match, "name"),
+                matchSource ?? string.Empty,
+                null,
+                RequiredString(match, "installed_version"),
+                OptionalString(match, "available_version") is { } availableVersion ? new[] { availableVersion } : Array.Empty<string>(),
+                OptionalString(match, "publisher"),
+                OptionalString(match, "scope"))));
+        }
+
+        return new CollectionResult<PSInstallResult>(results, warnings, Bool(matches, "truncated"));
+    }
+
+    public CommandResult<PSRepairResult> RepairPackage(
+        PSCatalogPackage? inputObject,
+        string? version,
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        bool allowHashMismatch,
+        bool force,
+        string? log,
+        PSPackageRepairMode mode)
+    {
+        var request = new JsonObject
+        {
+            ["query"] = BuildPackageQuery(
+                id ?? inputObject?.Id,
+                name ?? inputObject?.Name,
+                moniker ?? inputObject?.Moniker,
+                source ?? inputObject?.Source,
+                query,
+                null,
+                null,
+                0,
+                PSPackageFieldMatchOption.EqualsCaseInsensitive),
+            ["ignore_security_hash"] = allowHashMismatch,
+            ["force"] = force,
+            ["mode"] = ToInstallerMode(mode),
+        };
+        SetIfNotNull(request, "log_path", Normalize(log));
+        SetIfNotNull((JsonObject)request["query"]!, "version", version ?? GetCatalogVersion(inputObject));
+
+        var result = RequiredObject(_packageManager.RepairJson(ToJsonString(request)));
+        var repairedVersion = Normalize(version) ?? GetCatalogVersion(inputObject) ?? RequiredString(result, "version");
+        return new CommandResult<PSRepairResult>(ToPsRepairResult(result, request, new PSInstalledCatalogPackage(
+            RequiredString(result, "package_id"),
+            inputObject?.Name ?? RequiredString(result, "package_id"),
+            Normalize(source ?? inputObject?.Source) ?? string.Empty,
+            null,
+            repairedVersion,
+            Array.Empty<string>(),
+            null,
+            (inputObject as PSInstalledCatalogPackage)?.Scope)), WarningsFrom(result));
+    }
+
+    private static JsonObject BuildPackageQuery(
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        string? tag,
+        string? command,
+        uint count,
+        PSPackageFieldMatchOption matchOption)
+    {
+        var result = new JsonObject();
+        SetIfNotNull(result, "id", Normalize(id));
+        SetIfNotNull(result, "name", Normalize(name));
+        SetIfNotNull(result, "moniker", Normalize(moniker));
+        SetIfNotNull(result, "source", Normalize(source));
+        SetIfNotNull(result, "query", JoinQuery(query));
+        SetIfNotNull(result, "tag", Normalize(tag));
+        SetIfNotNull(result, "command", Normalize(command));
+        if (count != 0)
+            result["count"] = count;
+        result["exact"] = UsesExactMatch(matchOption);
+        return result;
+    }
+
+    private static JsonObject BuildListQuery(
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        string? tag,
+        string? command,
+        uint count,
+        PSPackageFieldMatchOption matchOption)
+    {
+        var result = new JsonObject();
+        SetIfNotNull(result, "id", Normalize(id));
+        SetIfNotNull(result, "name", Normalize(name));
+        SetIfNotNull(result, "moniker", Normalize(moniker));
+        SetIfNotNull(result, "source", Normalize(source));
+        SetIfNotNull(result, "query", JoinQuery(query));
+        SetIfNotNull(result, "tag", Normalize(tag));
+        SetIfNotNull(result, "command", Normalize(command));
+        if (count != 0)
+            result["count"] = count;
+        result["exact"] = UsesExactMatch(matchOption);
+        return result;
+    }
+
+    private static JsonObject BuildInstallRequest(
+        PSCatalogPackage? inputObject,
+        string? version,
+        string? id,
+        string? name,
+        string? moniker,
+        string? source,
+        string[]? query,
+        bool allowHashMismatch,
+        string? overrideArguments,
+        string? custom,
+        string? location,
+        string? log,
+        bool force,
+        bool skipDependencies,
+        string? locale,
+        PSPackageInstallScope scope,
+        PSProcessorArchitecture architecture,
+        PSPackageInstallMode mode,
+        PSPackageInstallerType installerType)
+    {
+        var queryObject = BuildPackageQuery(
+            id ?? inputObject?.Id,
+            name ?? inputObject?.Name,
+            moniker ?? inputObject?.Moniker,
+            source ?? inputObject?.Source,
+            query,
+            null,
+            null,
+            0,
+            PSPackageFieldMatchOption.EqualsCaseInsensitive);
+        SetIfNotNull(queryObject, "version", version ?? GetCatalogVersion(inputObject));
+        SetIfNotNull(queryObject, "locale", locale);
+        SetIfNotNull(queryObject, "installer_architecture", architecture == PSProcessorArchitecture.Default ? null : architecture.ToString());
+        SetIfNotNull(queryObject, "installer_type", installerType == PSPackageInstallerType.Default ? null : installerType.ToString());
+        SetIfNotNull(queryObject, "install_scope", scope == PSPackageInstallScope.Any ? null : scope.ToString());
+
+        var request = new JsonObject
+        {
+            ["query"] = queryObject,
+            ["force"] = force,
+            ["skip_dependencies"] = skipDependencies,
+            ["ignore_security_hash"] = allowHashMismatch,
+            ["mode"] = ToInstallerMode(mode),
+        };
+        SetIfNotNull(request, "override_args", Normalize(overrideArguments));
+        SetIfNotNull(request, "custom", Normalize(custom));
+        SetIfNotNull(request, "install_location", Normalize(location));
+        SetIfNotNull(request, "log_path", Normalize(log));
+        return request;
+    }
+
+    private static PSInstallResult ToPsInstallResult(JsonObject result, JsonObject request, PSCatalogPackage? inputObject)
+    {
+        var query = RequiredObject(request, "query");
+        var packageId = RequiredString(result, "package_id");
+        var identity = ResolveIdentity(packageId, OptionalString(query, "name") ?? inputObject?.Name, OptionalString(query, "source") ?? inputObject?.Source);
+        return new PSInstallResult
+        {
+            Id = packageId,
+            Name = identity.Name,
+            Source = identity.Source,
+            CorrelationData = OptionalString(result, "installer_path") ?? string.Empty,
+            InstallerErrorCode = unchecked((uint)Int(result, "exit_code")),
+            RebootRequired = false,
+            Status = OperationStatus(result),
+        };
+    }
+
+    private static PSUninstallResult ToPsUninstallResult(JsonObject result, JsonObject request, PSCatalogPackage? inputObject)
+    {
+        var query = RequiredObject(request, "query");
+        var packageId = RequiredString(result, "package_id");
+        var identity = ResolveIdentity(packageId, OptionalString(query, "name") ?? inputObject?.Name, OptionalString(query, "source") ?? inputObject?.Source);
+        return new PSUninstallResult
+        {
+            Id = packageId,
+            Name = identity.Name,
+            Source = identity.Source,
+            CorrelationData = OptionalString(result, "installer_path") ?? string.Empty,
+            UninstallerErrorCode = unchecked((uint)Int(result, "exit_code")),
+            RebootRequired = false,
+            Status = OperationStatus(result),
+        };
+    }
+
+    private static PSRepairResult ToPsRepairResult(JsonObject result, JsonObject request, PSCatalogPackage? inputObject)
+    {
+        var query = RequiredObject(request, "query");
+        var packageId = RequiredString(result, "package_id");
+        var identity = ResolveIdentity(packageId, OptionalString(query, "name") ?? inputObject?.Name, OptionalString(query, "source") ?? inputObject?.Source);
+        return new PSRepairResult
+        {
+            Id = packageId,
+            Name = identity.Name,
+            Source = identity.Source,
+            CorrelationData = OptionalString(result, "installer_path") ?? string.Empty,
+            RepairErrorCode = unchecked((uint)Int(result, "exit_code")),
+            RebootRequired = false,
+            Status = OperationStatus(result),
+        };
+    }
+
+    private static string OperationStatus(JsonObject result) =>
+        Bool(result, "success") ? "Ok" : Bool(result, "no_op") ? "NoOp" : "Error";
+
+    private static (string Name, string? Source) ResolveIdentity(string id, string? name, string? source) =>
+        (string.IsNullOrWhiteSpace(name) ? id : name!, Normalize(source));
+
+    private static List<string> HeaderWarnings(IDictionary? headers)
+    {
+        if (headers is null || headers.Count == 0)
+            return new List<string>();
+
+        return new List<string>
+        {
+            "Header is accepted for compatibility but the Rust COM core does not support per-request headers.",
+        };
+    }
+
+    private static void AddDownloadCompatibilityWarnings(
+        List<string> warnings,
+        bool skipDependencies,
+        bool skipMicrosoftStoreLicense)
+    {
+        if (skipDependencies)
+            warnings.Add("SkipDependencies does not affect Pinget export and was ignored.");
+    }
+
+    private static string? ToInstallerPlatform(PSWindowsPlatform platform)
+    {
+        switch (platform)
+        {
+            case PSWindowsPlatform.Universal:
+                return "Windows.Universal";
+            case PSWindowsPlatform.Desktop:
+                return "Windows.Desktop";
+            case PSWindowsPlatform.IoT:
+                return "Windows.IoT";
+            case PSWindowsPlatform.Team:
+                return "Windows.Team";
+            case PSWindowsPlatform.Holographic:
+                return "Windows.Holographic";
+            default:
+                return null;
+        }
+    }
+
+    private static string ToInstallerMode(PSPackageInstallMode mode)
+    {
+        switch (mode)
+        {
+            case PSPackageInstallMode.Silent:
+                return "Silent";
+            case PSPackageInstallMode.Interactive:
+                return "Interactive";
+            default:
+                return "SilentWithProgress";
+        }
+    }
+
+    private static string ToInstallerMode(PSPackageUninstallMode mode)
+    {
+        switch (mode)
+        {
+            case PSPackageUninstallMode.Silent:
+                return "Silent";
+            case PSPackageUninstallMode.Interactive:
+                return "Interactive";
+            default:
+                return "SilentWithProgress";
+        }
+    }
+
+    private static string ToInstallerMode(PSPackageRepairMode mode)
+    {
+        switch (mode)
+        {
+            case PSPackageRepairMode.Silent:
+                return "Silent";
+            case PSPackageRepairMode.Interactive:
+                return "Interactive";
+            default:
+                return "SilentWithProgress";
+        }
+    }
+
+    private static string? GetCatalogVersion(PSCatalogPackage? inputObject)
+    {
+        if (inputObject is PSFoundCatalogPackage found)
+            return found.Version;
+        if (inputObject is PSInstalledCatalogPackage installed && installed.AvailableVersions.Count > 0)
+            return installed.AvailableVersions[0];
+        if (inputObject is PSInstalledCatalogPackage installedPackage)
+            return installedPackage.InstalledVersion;
+        return null;
+    }
+
+    private static bool UsesExactMatch(PSPackageFieldMatchOption matchOption) =>
+        matchOption == PSPackageFieldMatchOption.Equals || matchOption == PSPackageFieldMatchOption.EqualsCaseInsensitive;
+
+    private static string? JoinQuery(string[]? query)
+    {
+        if (query is null || query.Length == 0)
+            return null;
+
+        var values = query.Where(value => !string.IsNullOrWhiteSpace(value)).ToArray();
+        return values.Length == 0 ? null : string.Join(" ", values);
+    }
+
+    private static string? Normalize(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static string ToJsonString(JsonObject value) => value.ToJsonString();
+
+    private static void SetIfNotNull(JsonObject target, string name, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            target[name] = value;
+    }
+
+    private static JsonObject RequiredObject(string json)
+    {
+        return JsonNode.Parse(json) as JsonObject
+            ?? throw new InvalidOperationException("The native Pinget COM bridge returned invalid JSON object data.");
+    }
+
+    private static JsonObject RequiredObject(JsonObject source, string name)
+    {
+        return source[name] as JsonObject
+            ?? throw new InvalidOperationException($"The native Pinget COM bridge returned an object without '{name}'.");
+    }
+
+    private static JsonArray RequiredArray(JsonObject source, string name)
+    {
+        return source[name] as JsonArray
+            ?? throw new InvalidOperationException($"The native Pinget COM bridge returned an object without '{name}'.");
+    }
+
+    private static List<string> WarningsFrom(JsonObject source) => StringArray(source, "warnings").ToList();
+
+    private static string[] StringArray(JsonObject source, string name)
+    {
+        return (source[name] as JsonArray)?
+            .Select(item => item?.GetValue<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!)
+            .ToArray() ?? Array.Empty<string>();
+    }
+
+    private static bool Bool(JsonObject source, string name) => source[name]?.GetValue<bool>() ?? false;
+
+    private static int Int(JsonObject source, string name) => source[name]?.GetValue<int>() ?? 0;
+
+    private static PSSourceResult ToSourceResult(JsonObject source)
+    {
+        return new PSSourceResult
+        {
+            Name = RequiredString(source, "name"),
+            Argument = RequiredString(source, "argument"),
+            Type = RequiredString(source, "type"),
+            TrustLevel = OptionalString(source, "trustLevel") ?? "None",
+            Explicit = source["explicit"]?.GetValue<bool>() ?? false,
+            Priority = source["priority"]?.GetValue<int>() ?? 0,
+            Identifier = RequiredString(source, "identifier"),
+            LastUpdate = ParseDateTime(OptionalString(source, "lastUpdate")),
+            SourceVersion = OptionalString(source, "sourceVersion"),
+        };
+    }
+
+    private static string RequiredString(JsonObject source, string name) =>
+        OptionalString(source, name) ?? throw new InvalidOperationException($"The native Pinget COM bridge returned a source without '{name}'.");
+
+    private static string? OptionalString(JsonObject source, string name) => source[name]?.GetValue<string>();
+
+    private static DateTime? ParseDateTime(string? value) =>
+        DateTime.TryParse(value, out var parsed) ? parsed : null;
+}
+#endif

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Engine/PowerShellEngineVersion.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Engine/PowerShellEngineVersion.cs
@@ -2,5 +2,5 @@ namespace Devolutions.Pinget.PowerShell.Engine;
 
 public static class PowerShellEngineVersion
 {
-    public const string Current = "0.1.0";
+    public const string Current = "0.2.0";
 }

--- a/dotnet/tests/Pinget.PowerShell.Tests.ps1
+++ b/dotnet/tests/Pinget.PowerShell.Tests.ps1
@@ -11,6 +11,8 @@ BeforeAll {
     $script:appRoot = Join-Path $script:testRoot 'app-root'
     $script:sourceName = 'PingetParitySource'
     $script:downloadDirectory = Join-Path $script:testRoot 'downloads'
+    $script:supportsPackageOperationTests = $true
+    $script:skipPackageOperationReason = 'The package source did not return the expected test package.'
 
     New-Item -ItemType Directory -Force -Path $script:testRoot, $script:appRoot, $script:downloadDirectory | Out-Null
     $env:LOCALAPPDATA = $script:testRoot
@@ -146,9 +148,19 @@ Describe 'Pinget package object parity' {
     BeforeAll {
         Add-PingetParitySource
         $script:foundPackage = Find-PingetPackage -Id 'WinMerge.WinMerge' -Source $script:sourceName | Select-Object -First 1
+        if ($null -eq $script:foundPackage)
+        {
+            $script:supportsPackageOperationTests = $false
+        }
     }
 
     It 'exposes upstream-like package members' {
+        if (-not $script:supportsPackageOperationTests)
+        {
+            Set-ItResult -Skipped -Because $script:skipPackageOperationReason
+            return
+        }
+
         $script:foundPackage | Should -Not -BeNullOrEmpty
         ($script:foundPackage | Get-Member -Name 'AvailableVersions').MemberType | Should -Be 'Property'
         ($script:foundPackage | Get-Member -Name 'CheckInstalledStatus').MemberType | Should -Be 'Method'
@@ -156,6 +168,12 @@ Describe 'Pinget package object parity' {
     }
 
     It 'returns package version info objects' {
+        if (-not $script:supportsPackageOperationTests)
+        {
+            Set-ItResult -Skipped -Because $script:skipPackageOperationReason
+            return
+        }
+
         $script:foundPackage.AvailableVersions.Count | Should -BeGreaterThan 0
 
         $version = $script:foundPackage.AvailableVersions[0]
@@ -178,6 +196,12 @@ Describe 'Pinget format data and result objects' {
     }
 
     It 'returns download results with common operation members' {
+        if (-not $script:supportsPackageOperationTests)
+        {
+            Set-ItResult -Skipped -Because $script:skipPackageOperationReason
+            return
+        }
+
         $warnings = @()
         $result = Export-PingetPackage `
             -Id 'WinMerge.WinMerge' `

--- a/dotnet/tests/RunTests.ps1
+++ b/dotnet/tests/RunTests.ps1
@@ -1,10 +1,48 @@
 [CmdletBinding()]
 param(
-    [string]$ModulePath = (Join-Path $PSScriptRoot '..\..\dist\powershell-module\Devolutions.Pinget.Client\Devolutions.Pinget.Client.psd1'),
+    [string]$ModulePath,
     [string]$SourceArgument = 'https://api.winget.pro/4259fd23-6fcd-46bf-9287-be8833cfbdd5'
 )
 
-Import-Module Pester -MinimumVersion 5.0.0
+try
+{
+    Import-Module Pester -MinimumVersion 5.0.0 -ErrorAction Stop
+}
+catch
+{
+    $powerShellModuleRoots = @(
+        (Join-Path ([Environment]::GetFolderPath('MyDocuments')) 'PowerShell\Modules\Pester')
+        (Join-Path $env:ProgramFiles 'PowerShell\Modules\Pester')
+    )
+    $pesterManifest = $null
+    foreach ($powerShellModuleRoot in $powerShellModuleRoots)
+    {
+        if (Test-Path -Path $powerShellModuleRoot)
+        {
+            $pesterManifest = Get-ChildItem -Path $powerShellModuleRoot -Filter Pester.psd1 -Recurse |
+                Where-Object { [version]$_.Directory.Name -ge [version]'5.0.0' } |
+                Sort-Object { [version]$_.Directory.Name } -Descending |
+                Select-Object -First 1 -ExpandProperty FullName
+
+            if (-not [string]::IsNullOrWhiteSpace($pesterManifest))
+            {
+                break
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($pesterManifest))
+    {
+        throw
+    }
+
+    Import-Module $pesterManifest -MinimumVersion 5.0.0 -ErrorAction Stop
+}
+
+if ([string]::IsNullOrWhiteSpace($ModulePath))
+{
+    $ModulePath = Join-Path $PSScriptRoot '..\..\dist\powershell-module\Devolutions.Pinget.Client\Devolutions.Pinget.Client.psd1'
+}
 
 if (-not (Test-Path -Path $ModulePath))
 {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/pinget-core",
     "crates/pinget-cli",
+    "crates/pinget-com",
 ]
 resolver = "3"
 

--- a/rust/crates/pinget-cli/Cargo.toml
+++ b/rust/crates/pinget-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinget-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [lints]
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
-pinget-core = { version = "0.1.0", path = "../pinget-core" }
+pinget-core = { version = "0.2.0", path = "../pinget-core" }
 chrono = "0.4.44"
 dirs = "6.0"
 jsonschema = "0.30"

--- a/rust/crates/pinget-com/Cargo.toml
+++ b/rust/crates/pinget-com/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pinget-com"
+version = "0.1.0"
+edition = "2024"
+description = "Windows-only native COM bridge for Pinget backed by pinget-core."
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1.0.102"
+pinget-core = { path = "../pinget-core" }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+] }

--- a/rust/crates/pinget-com/Cargo.toml
+++ b/rust/crates/pinget-com/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinget-com"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Windows-only native COM bridge for Pinget backed by pinget-core."
 license = "MIT"

--- a/rust/crates/pinget-com/src/lib.rs
+++ b/rust/crates/pinget-com/src/lib.rs
@@ -1,0 +1,1242 @@
+#![cfg(windows)]
+#![allow(clippy::multiple_unsafe_ops_per_block)]
+
+use std::ffi::c_void;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::{ptr, slice};
+
+use anyhow::{Context, Result};
+use pinget_core::{
+    InstallRequest, InstallerMode, ListQuery, PackageQuery, PinType, RepairRequest, Repository, SourceKind,
+    UninstallRequest,
+};
+use serde_json::{Value as JsonValue, json};
+use windows_sys::Win32::Foundation::{
+    CLASS_E_CLASSNOTAVAILABLE, CLASS_E_NOAGGREGATION, E_FAIL, E_INVALIDARG, E_NOINTERFACE, E_POINTER, S_FALSE, S_OK,
+    SysAllocStringLen, SysStringLen,
+};
+use windows_sys::core::{BSTR, GUID, HRESULT};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const IID_IUNKNOWN: GUID = guid(
+    0x00000000,
+    0x0000,
+    0x0000,
+    [0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46],
+);
+const IID_ICLASS_FACTORY: GUID = guid(
+    0x00000001,
+    0x0000,
+    0x0000,
+    [0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46],
+);
+
+// Devolutions.Pinget.Deployment.PackageManager
+const CLSID_PACKAGE_MANAGER: GUID = guid(
+    0x8F3C6294,
+    0x2BB9,
+    0x4F8C,
+    [0x87, 0xA8, 0x4D, 0x5C, 0x0A, 0x7B, 0xA1, 0x10],
+);
+
+// Devolutions.Pinget.Deployment.IPackageManager
+const IID_IPACKAGE_MANAGER: GUID = guid(
+    0x347FA969,
+    0xB65E,
+    0x4282,
+    [0x9E, 0x51, 0x2F, 0x89, 0x2E, 0x11, 0xA3, 0x22],
+);
+
+static ACTIVE_OBJECTS: AtomicU32 = AtomicU32::new(0);
+static SERVER_LOCKS: AtomicU32 = AtomicU32::new(0);
+
+const fn guid(data1: u32, data2: u16, data3: u16, data4: [u8; 8]) -> GUID {
+    GUID {
+        data1,
+        data2,
+        data3,
+        data4,
+    }
+}
+
+fn guid_eq(left: &GUID, right: &GUID) -> bool {
+    left.data1 == right.data1 && left.data2 == right.data2 && left.data3 == right.data3 && left.data4 == right.data4
+}
+
+#[repr(C)]
+struct UnknownVTable {
+    query_interface: unsafe extern "system" fn(*mut c_void, *const GUID, *mut *mut c_void) -> HRESULT,
+    add_ref: unsafe extern "system" fn(*mut c_void) -> u32,
+    release: unsafe extern "system" fn(*mut c_void) -> u32,
+}
+
+#[repr(C)]
+struct PackageManagerVTable {
+    unknown: UnknownVTable,
+    get_version: unsafe extern "system" fn(*mut PackageManagerObject, *mut BSTR) -> HRESULT,
+    get_default_app_root: unsafe extern "system" fn(*mut PackageManagerObject, *mut BSTR) -> HRESULT,
+    list_sources_json: unsafe extern "system" fn(*mut PackageManagerObject, *mut BSTR) -> HRESULT,
+    add_source: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, BSTR, BSTR, BSTR, i32, i32) -> HRESULT,
+    remove_source: unsafe extern "system" fn(*mut PackageManagerObject, BSTR) -> HRESULT,
+    reset_source: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, i32) -> HRESULT,
+    edit_source_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR) -> HRESULT,
+    update_sources_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    get_user_settings_json: unsafe extern "system" fn(*mut PackageManagerObject, *mut BSTR) -> HRESULT,
+    set_user_settings_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, i32, *mut BSTR) -> HRESULT,
+    test_user_settings_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, i32, *mut i32) -> HRESULT,
+    get_admin_settings_json: unsafe extern "system" fn(*mut PackageManagerObject, *mut BSTR) -> HRESULT,
+    set_admin_setting: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, i32) -> HRESULT,
+    reset_admin_setting: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, i32) -> HRESULT,
+    ensure_settings_files: unsafe extern "system" fn(*mut PackageManagerObject) -> HRESULT,
+    search_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    search_manifests_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    list_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    search_versions_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    show_versions_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    show_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    warm_cache_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    list_pins_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    add_pin: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, BSTR, BSTR, BSTR) -> HRESULT,
+    remove_pin: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, BSTR, *mut i32) -> HRESULT,
+    reset_pins: unsafe extern "system" fn(*mut PackageManagerObject, BSTR) -> HRESULT,
+    download_installer_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, BSTR, *mut BSTR) -> HRESULT,
+    install_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    uninstall_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    repair_json: unsafe extern "system" fn(*mut PackageManagerObject, BSTR, *mut BSTR) -> HRESULT,
+    get_last_error: unsafe extern "system" fn(*mut PackageManagerObject, *mut BSTR) -> HRESULT,
+}
+
+#[repr(C)]
+struct ClassFactoryVTable {
+    unknown: UnknownVTable,
+    create_instance:
+        unsafe extern "system" fn(*mut ClassFactoryObject, *mut c_void, *const GUID, *mut *mut c_void) -> HRESULT,
+    lock_server: unsafe extern "system" fn(*mut ClassFactoryObject, i32) -> HRESULT,
+}
+
+#[repr(C)]
+struct PackageManagerObject {
+    vtbl: *const PackageManagerVTable,
+    ref_count: AtomicU32,
+    repository: Mutex<Repository>,
+    last_error: Mutex<Option<String>>,
+}
+
+#[repr(C)]
+struct ClassFactoryObject {
+    vtbl: *const ClassFactoryVTable,
+    ref_count: AtomicU32,
+}
+
+impl PackageManagerObject {
+    fn new() -> Result<Box<Self>> {
+        let repository = Repository::open().context("failed to open Pinget repository")?;
+        ACTIVE_OBJECTS.fetch_add(1, Ordering::AcqRel);
+        Ok(Box::new(Self {
+            vtbl: &PACKAGE_MANAGER_VTBL,
+            ref_count: AtomicU32::new(1),
+            repository: Mutex::new(repository),
+            last_error: Mutex::new(None),
+        }))
+    }
+}
+
+impl Drop for PackageManagerObject {
+    fn drop(&mut self) {
+        ACTIVE_OBJECTS.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+impl ClassFactoryObject {
+    fn new() -> Self {
+        ACTIVE_OBJECTS.fetch_add(1, Ordering::AcqRel);
+        Self {
+            vtbl: &CLASS_FACTORY_VTBL,
+            ref_count: AtomicU32::new(1),
+        }
+    }
+}
+
+impl Drop for ClassFactoryObject {
+    fn drop(&mut self) {
+        ACTIVE_OBJECTS.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+static PACKAGE_MANAGER_VTBL: PackageManagerVTable = PackageManagerVTable {
+    unknown: UnknownVTable {
+        query_interface: package_manager_query_interface,
+        add_ref: package_manager_add_ref,
+        release: package_manager_release,
+    },
+    get_version: package_manager_get_version,
+    get_default_app_root: package_manager_get_default_app_root,
+    list_sources_json: package_manager_list_sources_json,
+    add_source: package_manager_add_source,
+    remove_source: package_manager_remove_source,
+    reset_source: package_manager_reset_source,
+    edit_source_json: package_manager_edit_source_json,
+    update_sources_json: package_manager_update_sources_json,
+    get_user_settings_json: package_manager_get_user_settings_json,
+    set_user_settings_json: package_manager_set_user_settings_json,
+    test_user_settings_json: package_manager_test_user_settings_json,
+    get_admin_settings_json: package_manager_get_admin_settings_json,
+    set_admin_setting: package_manager_set_admin_setting,
+    reset_admin_setting: package_manager_reset_admin_setting,
+    ensure_settings_files: package_manager_ensure_settings_files,
+    search_json: package_manager_search_json,
+    search_manifests_json: package_manager_search_manifests_json,
+    list_json: package_manager_list_json,
+    search_versions_json: package_manager_search_versions_json,
+    show_versions_json: package_manager_show_versions_json,
+    show_json: package_manager_show_json,
+    warm_cache_json: package_manager_warm_cache_json,
+    list_pins_json: package_manager_list_pins_json,
+    add_pin: package_manager_add_pin,
+    remove_pin: package_manager_remove_pin,
+    reset_pins: package_manager_reset_pins,
+    download_installer_json: package_manager_download_installer_json,
+    install_json: package_manager_install_json,
+    uninstall_json: package_manager_uninstall_json,
+    repair_json: package_manager_repair_json,
+    get_last_error: package_manager_get_last_error,
+};
+
+static CLASS_FACTORY_VTBL: ClassFactoryVTable = ClassFactoryVTable {
+    unknown: UnknownVTable {
+        query_interface: class_factory_query_interface,
+        add_ref: class_factory_add_ref,
+        release: class_factory_release,
+    },
+    create_instance: class_factory_create_instance,
+    lock_server: class_factory_lock_server,
+};
+
+unsafe extern "system" fn package_manager_query_interface(
+    this: *mut c_void,
+    riid: *const GUID,
+    object: *mut *mut c_void,
+) -> HRESULT {
+    if object.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: The out pointer was checked above and is owned by the caller for this call.
+    unsafe {
+        *object = ptr::null_mut();
+    }
+
+    if riid.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: riid is non-null and points to a GUID provided by the COM caller.
+    let requested = unsafe { *riid };
+    if !guid_eq(&requested, &IID_IUNKNOWN) && !guid_eq(&requested, &IID_IPACKAGE_MANAGER) {
+        return E_NOINTERFACE;
+    }
+
+    // SAFETY: this is a valid PackageManagerObject pointer for calls routed through this vtable.
+    unsafe {
+        package_manager_add_ref(this);
+        *object = this;
+    }
+
+    S_OK
+}
+
+unsafe extern "system" fn package_manager_add_ref(this: *mut c_void) -> u32 {
+    // SAFETY: COM routes this call only for live PackageManagerObject instances.
+    let object = unsafe { &*(this.cast::<PackageManagerObject>()) };
+    object.ref_count.fetch_add(1, Ordering::AcqRel) + 1
+}
+
+unsafe extern "system" fn package_manager_release(this: *mut c_void) -> u32 {
+    // SAFETY: COM routes this call only for live PackageManagerObject instances.
+    let object = unsafe { &*(this.cast::<PackageManagerObject>()) };
+    let count = object.ref_count.fetch_sub(1, Ordering::AcqRel) - 1;
+    if count == 0 {
+        // SAFETY: The final Release owns the original Box allocated by Box::into_raw.
+        unsafe {
+            drop(Box::from_raw(this.cast::<PackageManagerObject>()));
+        }
+    }
+
+    count
+}
+
+unsafe extern "system" fn package_manager_get_version(_this: *mut PackageManagerObject, value: *mut BSTR) -> HRESULT {
+    write_bstr(value, VERSION)
+}
+
+unsafe extern "system" fn package_manager_get_default_app_root(
+    this: *mut PackageManagerObject,
+    value: *mut BSTR,
+) -> HRESULT {
+    if this.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: this is checked non-null and is a PackageManagerObject for this vtable method.
+    let object = unsafe { &*this };
+    let guard = match object.repository.lock() {
+        Ok(guard) => guard,
+        Err(_) => return E_FAIL,
+    };
+
+    write_bstr(value, &guard.app_root().display().to_string())
+}
+
+unsafe extern "system" fn package_manager_list_sources_json(
+    this: *mut PackageManagerObject,
+    value: *mut BSTR,
+) -> HRESULT {
+    if this.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: this is checked non-null and is a PackageManagerObject for this vtable method.
+    let object = unsafe { &*this };
+    let guard = match object.repository.lock() {
+        Ok(guard) => guard,
+        Err(_) => return E_FAIL,
+    };
+
+    let sources = guard
+        .list_sources()
+        .into_iter()
+        .map(|source| {
+            serde_json::json!({
+                "name": source.name,
+                "argument": source.arg,
+                "type": source_kind_name(source.kind),
+                "trustLevel": source.trust_level,
+                "explicit": source.explicit,
+                "priority": source.priority,
+                "identifier": source.identifier,
+                "lastUpdate": source.last_update.map(|value| value.to_rfc3339()),
+                "sourceVersion": source.source_version,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    match serde_json::to_string(&sources) {
+        Ok(json) => write_bstr(value, &json),
+        Err(_) => E_FAIL,
+    }
+}
+
+unsafe extern "system" fn package_manager_add_source(
+    this: *mut PackageManagerObject,
+    name: BSTR,
+    argument: BSTR,
+    source_type: BSTR,
+    trust_level: BSTR,
+    explicit: i32,
+    priority: i32,
+) -> HRESULT {
+    if this.is_null() {
+        return E_POINTER;
+    }
+
+    let name = match required_bstr(name) {
+        Ok(value) => value,
+        Err(hr) => return hr,
+    };
+    let argument = match required_bstr(argument) {
+        Ok(value) => value,
+        Err(hr) => return hr,
+    };
+    let source_type = match optional_bstr(source_type) {
+        Ok(value) => value,
+        Err(hr) => return hr,
+    };
+    let trust_level = match optional_bstr(trust_level) {
+        Ok(value) => value,
+        Err(hr) => return hr,
+    };
+    let source_kind = match parse_source_kind(source_type.as_deref()) {
+        Some(value) => value,
+        None => return E_INVALIDARG,
+    };
+
+    // SAFETY: this is checked non-null and is a PackageManagerObject for this vtable method.
+    let object = unsafe { &*this };
+    let mut guard = match object.repository.lock() {
+        Ok(guard) => guard,
+        Err(_) => return E_FAIL,
+    };
+
+    match guard.add_source_with_metadata(
+        &name,
+        &argument,
+        source_kind,
+        trust_level.as_deref(),
+        explicit != 0,
+        priority,
+    ) {
+        Ok(()) => S_OK,
+        Err(_) => E_FAIL,
+    }
+}
+
+unsafe extern "system" fn package_manager_remove_source(this: *mut PackageManagerObject, name: BSTR) -> HRESULT {
+    if this.is_null() {
+        return E_POINTER;
+    }
+
+    let name = match required_bstr(name) {
+        Ok(value) => value,
+        Err(hr) => return hr,
+    };
+
+    // SAFETY: this is checked non-null and is a PackageManagerObject for this vtable method.
+    let object = unsafe { &*this };
+    let mut guard = match object.repository.lock() {
+        Ok(guard) => guard,
+        Err(_) => return E_FAIL,
+    };
+
+    match guard.remove_source(&name) {
+        Ok(()) => S_OK,
+        Err(_) => E_FAIL,
+    }
+}
+
+unsafe extern "system" fn package_manager_reset_source(
+    this: *mut PackageManagerObject,
+    name: BSTR,
+    all: i32,
+) -> HRESULT {
+    if this.is_null() {
+        return E_POINTER;
+    }
+
+    let name = match optional_bstr(name) {
+        Ok(value) => value,
+        Err(hr) => return hr,
+    };
+
+    // SAFETY: this is checked non-null and is a PackageManagerObject for this vtable method.
+    let object = unsafe { &*this };
+    let mut guard = match object.repository.lock() {
+        Ok(guard) => guard,
+        Err(_) => return E_FAIL,
+    };
+
+    let result = if all != 0 {
+        guard.reset_sources()
+    } else if let Some(name) = name.as_deref() {
+        guard.reset_source(name)
+    } else {
+        return E_INVALIDARG;
+    };
+
+    match result {
+        Ok(()) => S_OK,
+        Err(_) => E_FAIL,
+    }
+}
+
+unsafe extern "system" fn package_manager_edit_source_json(this: *mut PackageManagerObject, request: BSTR) -> HRESULT {
+    with_repository_mut(this, |repository| {
+        let request = json_from_bstr(request)?;
+        let name = required_json_string(&request, &["name"])?;
+        let explicit = optional_json_bool(&request, &["explicit", "explicitSource"]);
+        let trust_level = optional_json_string(&request, &["trust_level", "trustLevel"]);
+        repository.edit_source(name, explicit, trust_level.as_deref())
+    })
+}
+
+unsafe extern "system" fn package_manager_update_sources_json(
+    this: *mut PackageManagerObject,
+    source_name: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let source_name = optional_bstr(source_name).map_err(|_| anyhow::anyhow!("invalid source name"))?;
+        repository.update_sources(source_name.as_deref())
+    })
+}
+
+unsafe extern "system" fn package_manager_get_user_settings_json(
+    this: *mut PackageManagerObject,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| repository.get_user_settings())
+}
+
+unsafe extern "system" fn package_manager_set_user_settings_json(
+    this: *mut PackageManagerObject,
+    settings: BSTR,
+    merge: i32,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let settings = json_from_bstr(settings)?;
+        repository.set_user_settings(&settings, merge != 0)
+    })
+}
+
+unsafe extern "system" fn package_manager_test_user_settings_json(
+    this: *mut PackageManagerObject,
+    expected: BSTR,
+    ignore_not_set: i32,
+    matched: *mut i32,
+) -> HRESULT {
+    if matched.is_null() {
+        return E_POINTER;
+    }
+
+    with_repository_mut(this, |repository| {
+        let expected = json_from_bstr(expected)?;
+        let result = repository.test_user_settings(&expected, ignore_not_set != 0)?;
+        // SAFETY: matched was checked non-null and points to caller-owned writable storage.
+        unsafe {
+            *matched = i32::from(result);
+        }
+        Ok(())
+    })
+}
+
+unsafe extern "system" fn package_manager_get_admin_settings_json(
+    this: *mut PackageManagerObject,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| repository.get_admin_settings())
+}
+
+unsafe extern "system" fn package_manager_set_admin_setting(
+    this: *mut PackageManagerObject,
+    name: BSTR,
+    enabled: i32,
+) -> HRESULT {
+    with_repository_mut(this, |repository| {
+        let name = required_bstr(name).map_err(|_| anyhow::anyhow!("setting name is required"))?;
+        repository.set_admin_setting(&name, enabled != 0)
+    })
+}
+
+unsafe extern "system" fn package_manager_reset_admin_setting(
+    this: *mut PackageManagerObject,
+    name: BSTR,
+    reset_all: i32,
+) -> HRESULT {
+    with_repository_mut(this, |repository| {
+        let name = optional_bstr(name).map_err(|_| anyhow::anyhow!("invalid setting name"))?;
+        repository.reset_admin_setting(name.as_deref(), reset_all != 0)
+    })
+}
+
+unsafe extern "system" fn package_manager_ensure_settings_files(this: *mut PackageManagerObject) -> HRESULT {
+    with_repository_mut(this, |repository| repository.ensure_settings_files())
+}
+
+unsafe extern "system" fn package_manager_search_json(
+    this: *mut PackageManagerObject,
+    query: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let query = package_query_from_json(&json_from_bstr(query)?)?;
+        repository.search(&query)
+    })
+}
+
+unsafe extern "system" fn package_manager_search_manifests_json(
+    this: *mut PackageManagerObject,
+    query: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let query = package_query_from_json(&json_from_bstr(query)?)?;
+        repository.search_manifests(&query)
+    })
+}
+
+unsafe extern "system" fn package_manager_list_json(
+    this: *mut PackageManagerObject,
+    query: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let query = list_query_from_json(&json_from_bstr(query)?)?;
+        repository.list(&query)
+    })
+}
+
+unsafe extern "system" fn package_manager_search_versions_json(
+    this: *mut PackageManagerObject,
+    query: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let query = package_query_from_json(&json_from_bstr(query)?)?;
+        repository.search_versions(&query)
+    })
+}
+
+unsafe extern "system" fn package_manager_show_versions_json(
+    this: *mut PackageManagerObject,
+    query: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let query = package_query_from_json(&json_from_bstr(query)?)?;
+        repository.show_versions(&query)
+    })
+}
+
+unsafe extern "system" fn package_manager_show_json(
+    this: *mut PackageManagerObject,
+    query: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json_value(this, value, |repository| {
+        let query = package_query_from_json(&json_from_bstr(query)?)?;
+        let show = repository.show(&query)?;
+        let structured_document = show.structured_document();
+        let mut result = serde_json::to_value(&show)?;
+        if let JsonValue::Object(object) = &mut result {
+            object.insert("structured_document".to_owned(), structured_document);
+        }
+        Ok(result)
+    })
+}
+
+unsafe extern "system" fn package_manager_warm_cache_json(
+    this: *mut PackageManagerObject,
+    query: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let query = package_query_from_json(&json_from_bstr(query)?)?;
+        repository.warm_cache(&query)
+    })
+}
+
+unsafe extern "system" fn package_manager_list_pins_json(
+    this: *mut PackageManagerObject,
+    source_id: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let source_id = optional_bstr(source_id).map_err(|_| anyhow::anyhow!("invalid source id"))?;
+        repository.list_pins(source_id.as_deref())
+    })
+}
+
+unsafe extern "system" fn package_manager_add_pin(
+    this: *mut PackageManagerObject,
+    package_id: BSTR,
+    version: BSTR,
+    source_id: BSTR,
+    pin_type: BSTR,
+) -> HRESULT {
+    with_repository_mut(this, |repository| {
+        let package_id = required_bstr(package_id).map_err(|_| anyhow::anyhow!("package id is required"))?;
+        let version = required_bstr(version).map_err(|_| anyhow::anyhow!("version is required"))?;
+        let source_id = required_bstr(source_id).map_err(|_| anyhow::anyhow!("source id is required"))?;
+        let pin_type = required_bstr(pin_type).map_err(|_| anyhow::anyhow!("pin type is required"))?;
+        repository.add_pin(&package_id, &version, &source_id, parse_pin_type(&pin_type)?)
+    })
+}
+
+unsafe extern "system" fn package_manager_remove_pin(
+    this: *mut PackageManagerObject,
+    package_id: BSTR,
+    source_id: BSTR,
+    removed: *mut i32,
+) -> HRESULT {
+    if removed.is_null() {
+        return E_POINTER;
+    }
+
+    with_repository_mut(this, |repository| {
+        let package_id = required_bstr(package_id).map_err(|_| anyhow::anyhow!("package id is required"))?;
+        let source_id = optional_bstr(source_id).map_err(|_| anyhow::anyhow!("invalid source id"))?;
+        let result = repository.remove_pin(&package_id, source_id.as_deref())?;
+        // SAFETY: removed was checked non-null and points to caller-owned writable storage.
+        unsafe {
+            *removed = i32::from(result);
+        }
+        Ok(())
+    })
+}
+
+unsafe extern "system" fn package_manager_reset_pins(this: *mut PackageManagerObject, source_id: BSTR) -> HRESULT {
+    with_repository_mut(this, |repository| {
+        let source_id = optional_bstr(source_id).map_err(|_| anyhow::anyhow!("invalid source id"))?;
+        repository.reset_pins(source_id.as_deref())
+    })
+}
+
+unsafe extern "system" fn package_manager_download_installer_json(
+    this: *mut PackageManagerObject,
+    request: BSTR,
+    download_dir: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json_value(this, value, |repository| {
+        let request = install_request_from_json(&json_from_bstr(request)?)?;
+        let download_dir =
+            required_bstr(download_dir).map_err(|_| anyhow::anyhow!("download directory is required"))?;
+        let (manifest, installer_path) =
+            repository.download_installer_for_request(&request, Path::new(&download_dir))?;
+        Ok(json!({
+            "manifest": manifest,
+            "installer_path": installer_path,
+        }))
+    })
+}
+
+unsafe extern "system" fn package_manager_install_json(
+    this: *mut PackageManagerObject,
+    request: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let request = install_request_from_json(&json_from_bstr(request)?)?;
+        repository.install_request(&request)
+    })
+}
+
+unsafe extern "system" fn package_manager_uninstall_json(
+    this: *mut PackageManagerObject,
+    request: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let request = uninstall_request_from_json(&json_from_bstr(request)?)?;
+        repository.uninstall_request(&request)
+    })
+}
+
+unsafe extern "system" fn package_manager_repair_json(
+    this: *mut PackageManagerObject,
+    request: BSTR,
+    value: *mut BSTR,
+) -> HRESULT {
+    with_repository_json(this, value, |repository| {
+        let request = repair_request_from_json(&json_from_bstr(request)?)?;
+        repository.repair(&request)
+    })
+}
+
+unsafe extern "system" fn package_manager_get_last_error(this: *mut PackageManagerObject, value: *mut BSTR) -> HRESULT {
+    if this.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: this is checked non-null and is a PackageManagerObject for this vtable method.
+    let object = unsafe { &*this };
+    let guard = match object.last_error.lock() {
+        Ok(guard) => guard,
+        Err(_) => return E_FAIL,
+    };
+
+    write_bstr(value, guard.as_deref().unwrap_or_default())
+}
+
+unsafe extern "system" fn class_factory_query_interface(
+    this: *mut c_void,
+    riid: *const GUID,
+    object: *mut *mut c_void,
+) -> HRESULT {
+    if object.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: The out pointer was checked above and is owned by the caller for this call.
+    unsafe {
+        *object = ptr::null_mut();
+    }
+
+    if riid.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: riid is non-null and points to a GUID provided by the COM caller.
+    let requested = unsafe { *riid };
+    if !guid_eq(&requested, &IID_IUNKNOWN) && !guid_eq(&requested, &IID_ICLASS_FACTORY) {
+        return E_NOINTERFACE;
+    }
+
+    // SAFETY: this is a valid ClassFactoryObject pointer for calls routed through this vtable.
+    unsafe {
+        class_factory_add_ref(this);
+        *object = this;
+    }
+
+    S_OK
+}
+
+unsafe extern "system" fn class_factory_add_ref(this: *mut c_void) -> u32 {
+    // SAFETY: COM routes this call only for live ClassFactoryObject instances.
+    let object = unsafe { &*(this.cast::<ClassFactoryObject>()) };
+    object.ref_count.fetch_add(1, Ordering::AcqRel) + 1
+}
+
+unsafe extern "system" fn class_factory_release(this: *mut c_void) -> u32 {
+    // SAFETY: COM routes this call only for live ClassFactoryObject instances.
+    let object = unsafe { &*(this.cast::<ClassFactoryObject>()) };
+    let count = object.ref_count.fetch_sub(1, Ordering::AcqRel) - 1;
+    if count == 0 {
+        // SAFETY: The final Release owns the original Box allocated by Box::into_raw.
+        unsafe {
+            drop(Box::from_raw(this.cast::<ClassFactoryObject>()));
+        }
+    }
+
+    count
+}
+
+unsafe extern "system" fn class_factory_create_instance(
+    _this: *mut ClassFactoryObject,
+    outer: *mut c_void,
+    riid: *const GUID,
+    object: *mut *mut c_void,
+) -> HRESULT {
+    if !outer.is_null() {
+        return CLASS_E_NOAGGREGATION;
+    }
+
+    // SAFETY: create_package_manager validates all caller-provided pointers.
+    unsafe { create_package_manager(riid, object) }
+}
+
+unsafe extern "system" fn class_factory_lock_server(_this: *mut ClassFactoryObject, lock: i32) -> HRESULT {
+    if lock != 0 {
+        SERVER_LOCKS.fetch_add(1, Ordering::AcqRel);
+    } else {
+        SERVER_LOCKS.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    S_OK
+}
+
+fn with_repository_mut(this: *mut PackageManagerObject, action: impl FnOnce(&mut Repository) -> Result<()>) -> HRESULT {
+    if this.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: this is checked non-null and is a PackageManagerObject for this vtable method.
+    let object = unsafe { &*this };
+    clear_last_error(object);
+    let mut guard = match object.repository.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            set_last_error(object, "Pinget repository lock was poisoned.");
+            return E_FAIL;
+        }
+    };
+
+    match action(&mut guard) {
+        Ok(()) => S_OK,
+        Err(error) => {
+            set_last_error(object, error.to_string());
+            E_FAIL
+        }
+    }
+}
+
+fn with_repository_json<T: serde::Serialize>(
+    this: *mut PackageManagerObject,
+    value: *mut BSTR,
+    action: impl FnOnce(&mut Repository) -> Result<T>,
+) -> HRESULT {
+    with_repository_json_value(this, value, |repository| Ok(serde_json::to_value(action(repository)?)?))
+}
+
+fn with_repository_json_value(
+    this: *mut PackageManagerObject,
+    value: *mut BSTR,
+    action: impl FnOnce(&mut Repository) -> Result<JsonValue>,
+) -> HRESULT {
+    if this.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: this is checked non-null and is a PackageManagerObject for this vtable method.
+    let object = unsafe { &*this };
+    clear_last_error(object);
+    let mut guard = match object.repository.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            set_last_error(object, "Pinget repository lock was poisoned.");
+            return E_FAIL;
+        }
+    };
+
+    let result = match action(&mut guard).and_then(|value| Ok(serde_json::to_string(&value)?)) {
+        Ok(json) => json,
+        Err(error) => {
+            set_last_error(object, error.to_string());
+            return E_FAIL;
+        }
+    };
+
+    write_bstr(value, &result)
+}
+
+fn clear_last_error(object: &PackageManagerObject) {
+    if let Ok(mut last_error) = object.last_error.lock() {
+        *last_error = None;
+    }
+}
+
+fn set_last_error(object: &PackageManagerObject, error: impl Into<String>) {
+    if let Ok(mut last_error) = object.last_error.lock() {
+        *last_error = Some(error.into());
+    }
+}
+
+fn source_kind_name(kind: SourceKind) -> &'static str {
+    match kind {
+        SourceKind::PreIndexed => "Microsoft.PreIndexed.Package",
+        SourceKind::Rest => "Microsoft.Rest",
+    }
+}
+
+fn parse_source_kind(value: Option<&str>) -> Option<SourceKind> {
+    match value {
+        None => Some(SourceKind::Rest),
+        Some(value) if value.eq_ignore_ascii_case("rest") || value.eq_ignore_ascii_case("Microsoft.Rest") => {
+            Some(SourceKind::Rest)
+        }
+        Some(value)
+            if value.eq_ignore_ascii_case("preindexed")
+                || value.eq_ignore_ascii_case("pre-indexed")
+                || value.eq_ignore_ascii_case("Microsoft.PreIndexed.Package") =>
+        {
+            Some(SourceKind::PreIndexed)
+        }
+        _ => None,
+    }
+}
+
+fn required_bstr(value: BSTR) -> Result<String, HRESULT> {
+    let value = optional_bstr(value)?;
+    match value {
+        Some(value) if !value.trim().is_empty() => Ok(value),
+        _ => Err(E_INVALIDARG),
+    }
+}
+
+fn optional_bstr(value: BSTR) -> Result<Option<String>, HRESULT> {
+    if value.is_null() {
+        return Ok(None);
+    }
+
+    // SAFETY: value is a BSTR pointer provided by the COM caller.
+    let len = unsafe { SysStringLen(value) };
+    let Ok(len) = usize::try_from(len) else {
+        return Err(E_INVALIDARG);
+    };
+
+    // SAFETY: value points to a BSTR containing len UTF-16 code units.
+    let slice = unsafe { slice::from_raw_parts(value, len) };
+    let text = match String::from_utf16(slice) {
+        Ok(value) => value,
+        Err(_) => return Err(E_INVALIDARG),
+    };
+
+    if text.trim().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(text))
+    }
+}
+
+fn json_from_bstr(value: BSTR) -> Result<JsonValue> {
+    let text = required_bstr(value).map_err(|_| anyhow::anyhow!("JSON input is required"))?;
+    Ok(serde_json::from_str(&text)?)
+}
+
+fn package_query_from_json(value: &JsonValue) -> Result<PackageQuery> {
+    Ok(PackageQuery {
+        query: optional_json_string(value, &["query"]),
+        id: optional_json_string(value, &["id"]),
+        name: optional_json_string(value, &["name"]),
+        moniker: optional_json_string(value, &["moniker"]),
+        tag: optional_json_string(value, &["tag"]),
+        command: optional_json_string(value, &["command"]),
+        source: optional_json_string(value, &["source"]),
+        count: optional_json_usize(value, &["count"]),
+        exact: optional_json_bool(value, &["exact"]).unwrap_or(false),
+        version: optional_json_string(value, &["version"]),
+        channel: optional_json_string(value, &["channel"]),
+        locale: optional_json_string(value, &["locale"]),
+        installer_type: optional_json_string(value, &["installer_type", "installerType"]),
+        installer_architecture: optional_json_string(value, &["installer_architecture", "installerArchitecture"]),
+        platform: optional_json_string(value, &["platform"]),
+        os_version: optional_json_string(value, &["os_version", "osVersion"]),
+        install_scope: optional_json_string(value, &["install_scope", "installScope"]),
+    })
+}
+
+fn list_query_from_json(value: &JsonValue) -> Result<ListQuery> {
+    Ok(ListQuery {
+        query: optional_json_string(value, &["query"]),
+        id: optional_json_string(value, &["id"]),
+        name: optional_json_string(value, &["name"]),
+        moniker: optional_json_string(value, &["moniker"]),
+        tag: optional_json_string(value, &["tag"]),
+        command: optional_json_string(value, &["command"]),
+        product_code: optional_json_string(value, &["product_code", "productCode"]),
+        version: optional_json_string(value, &["version"]),
+        source: optional_json_string(value, &["source"]),
+        count: optional_json_usize(value, &["count"]),
+        exact: optional_json_bool(value, &["exact"]).unwrap_or(false),
+        install_scope: optional_json_string(value, &["install_scope", "installScope"]),
+        upgrade_only: optional_json_bool(value, &["upgrade_only", "upgradeOnly"]).unwrap_or(false),
+        include_unknown: optional_json_bool(value, &["include_unknown", "includeUnknown"]).unwrap_or(false),
+        include_pinned: optional_json_bool(value, &["include_pinned", "includePinned"]).unwrap_or(false),
+    })
+}
+
+fn install_request_from_json(value: &JsonValue) -> Result<InstallRequest> {
+    let query = nested_json(value, &["query"])
+        .map(package_query_from_json)
+        .transpose()?
+        .unwrap_or_default();
+    let mut request = InstallRequest::new(query);
+    request.manifest_path = optional_path(value, &["manifest_path", "manifestPath"]);
+    request.mode = installer_mode_from_json(value, &["mode"])?;
+    request.log_path = optional_path(value, &["log_path", "logPath"]);
+    request.custom = optional_json_string(value, &["custom"]);
+    request.override_args = optional_json_string(value, &["override_args", "overrideArgs", "override"]);
+    request.install_location = optional_json_string(value, &["install_location", "installLocation"]);
+    request.skip_dependencies = optional_json_bool(value, &["skip_dependencies", "skipDependencies"]).unwrap_or(false);
+    request.dependencies_only = optional_json_bool(value, &["dependencies_only", "dependenciesOnly"]).unwrap_or(false);
+    request.accept_package_agreements =
+        optional_json_bool(value, &["accept_package_agreements", "acceptPackageAgreements"]).unwrap_or(false);
+    request.force = optional_json_bool(value, &["force"]).unwrap_or(false);
+    request.rename = optional_json_string(value, &["rename"]);
+    request.uninstall_previous =
+        optional_json_bool(value, &["uninstall_previous", "uninstallPrevious"]).unwrap_or(false);
+    request.ignore_security_hash =
+        optional_json_bool(value, &["ignore_security_hash", "ignoreSecurityHash"]).unwrap_or(false);
+    request.dependency_source = optional_json_string(value, &["dependency_source", "dependencySource"]);
+    request.no_upgrade = optional_json_bool(value, &["no_upgrade", "noUpgrade"]).unwrap_or(false);
+    Ok(request)
+}
+
+fn uninstall_request_from_json(value: &JsonValue) -> Result<UninstallRequest> {
+    let query = nested_json(value, &["query"])
+        .map(package_query_from_json)
+        .transpose()?
+        .unwrap_or_default();
+    let mut request = UninstallRequest::new(query);
+    request.manifest_path = optional_path(value, &["manifest_path", "manifestPath"]);
+    request.product_code = optional_json_string(value, &["product_code", "productCode"]);
+    request.mode = installer_mode_from_json(value, &["mode"])?;
+    request.all_versions = optional_json_bool(value, &["all_versions", "allVersions"]).unwrap_or(false);
+    request.force = optional_json_bool(value, &["force"]).unwrap_or(false);
+    request.purge = optional_json_bool(value, &["purge"]).unwrap_or(false);
+    request.preserve = optional_json_bool(value, &["preserve"]).unwrap_or(false);
+    request.log_path = optional_path(value, &["log_path", "logPath"]);
+    Ok(request)
+}
+
+fn repair_request_from_json(value: &JsonValue) -> Result<RepairRequest> {
+    let query = nested_json(value, &["query"])
+        .map(package_query_from_json)
+        .transpose()?
+        .unwrap_or_default();
+    let mut request = RepairRequest::new(query);
+    request.manifest_path = optional_path(value, &["manifest_path", "manifestPath"]);
+    request.product_code = optional_json_string(value, &["product_code", "productCode"]);
+    request.mode = installer_mode_from_json(value, &["mode"])?;
+    request.log_path = optional_path(value, &["log_path", "logPath"]);
+    request.accept_package_agreements =
+        optional_json_bool(value, &["accept_package_agreements", "acceptPackageAgreements"]).unwrap_or(false);
+    request.force = optional_json_bool(value, &["force"]).unwrap_or(false);
+    request.ignore_security_hash =
+        optional_json_bool(value, &["ignore_security_hash", "ignoreSecurityHash"]).unwrap_or(false);
+    Ok(request)
+}
+
+fn installer_mode_from_json(value: &JsonValue, names: &[&str]) -> Result<InstallerMode> {
+    match optional_json_string(value, names).as_deref() {
+        None | Some("") | Some("Default") | Some("SilentWithProgress") => Ok(InstallerMode::SilentWithProgress),
+        Some(value) if value.eq_ignore_ascii_case("Silent") => Ok(InstallerMode::Silent),
+        Some(value) if value.eq_ignore_ascii_case("Interactive") => Ok(InstallerMode::Interactive),
+        Some(value) if value.eq_ignore_ascii_case("SilentWithProgress") => Ok(InstallerMode::SilentWithProgress),
+        Some(value) => Err(anyhow::anyhow!("unsupported installer mode '{value}'")),
+    }
+}
+
+fn parse_pin_type(value: &str) -> Result<PinType> {
+    if value.eq_ignore_ascii_case("Pinning") {
+        Ok(PinType::Pinning)
+    } else if value.eq_ignore_ascii_case("Blocking") {
+        Ok(PinType::Blocking)
+    } else if value.eq_ignore_ascii_case("Gating") {
+        Ok(PinType::Gating)
+    } else {
+        Err(anyhow::anyhow!("unsupported pin type '{value}'"))
+    }
+}
+
+fn required_json_string<'a>(value: &'a JsonValue, names: &[&str]) -> Result<&'a str> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(JsonValue::as_str))
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("required JSON string is missing"))
+}
+
+fn optional_json_string(value: &JsonValue, names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(JsonValue::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn optional_json_bool(value: &JsonValue, names: &[&str]) -> Option<bool> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(JsonValue::as_bool))
+}
+
+fn optional_json_usize(value: &JsonValue, names: &[&str]) -> Option<usize> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(JsonValue::as_u64))
+        .and_then(|value| usize::try_from(value).ok())
+}
+
+fn nested_json<'a>(value: &'a JsonValue, names: &[&str]) -> Option<&'a JsonValue> {
+    names.iter().find_map(|name| value.get(*name))
+}
+
+fn optional_path(value: &JsonValue, names: &[&str]) -> Option<PathBuf> {
+    optional_json_string(value, names).map(PathBuf::from)
+}
+
+fn write_bstr(value: *mut BSTR, text: &str) -> HRESULT {
+    if value.is_null() {
+        return E_POINTER;
+    }
+
+    let utf16 = text.encode_utf16().collect::<Vec<_>>();
+    let Ok(len) = u32::try_from(utf16.len()) else {
+        return E_FAIL;
+    };
+
+    // SAFETY: The UTF-16 buffer is valid for len code units and SysAllocStringLen copies it.
+    let bstr = unsafe { SysAllocStringLen(utf16.as_ptr(), len) };
+    if bstr.is_null() && len != 0 {
+        return E_FAIL;
+    }
+
+    // SAFETY: The out pointer was checked above and receives ownership of the BSTR for the caller to free.
+    unsafe {
+        *value = bstr;
+    }
+
+    S_OK
+}
+
+unsafe fn create_package_manager(riid: *const GUID, object: *mut *mut c_void) -> HRESULT {
+    if object.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: The out pointer was checked above and is owned by the caller for this call.
+    unsafe {
+        *object = ptr::null_mut();
+    }
+
+    let package_manager = match PackageManagerObject::new() {
+        Ok(package_manager) => package_manager,
+        Err(_) => return E_FAIL,
+    };
+
+    let raw = Box::into_raw(package_manager);
+    // SAFETY: raw is a newly allocated PackageManagerObject with a valid vtable.
+    let hr = unsafe { package_manager_query_interface(raw.cast::<c_void>(), riid, object) };
+    // SAFETY: Release balances the initial reference held by raw; successful QueryInterface has added caller's ref.
+    unsafe {
+        package_manager_release(raw.cast::<c_void>());
+    }
+
+    hr
+}
+
+/// Creates a Pinget package manager COM object for direct, registration-free activation.
+///
+/// # Safety
+///
+/// `riid` must be either null only when the function is expected to fail with `E_POINTER`, or point to a valid
+/// interface GUID for the duration of the call. `object` must point to writable storage for one COM interface pointer.
+/// On success, the caller owns one reference and must release it with `IUnknown::Release`.
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn PingetCreatePackageManager(riid: *const GUID, object: *mut *mut c_void) -> HRESULT {
+    // SAFETY: create_package_manager validates all caller-provided pointers.
+    unsafe { create_package_manager(riid, object) }
+}
+
+/// Returns the class factory for the Pinget package manager class.
+///
+/// # Safety
+///
+/// `clsid` and `riid` must be either null only when the function is expected to fail with `E_POINTER`, or point to
+/// valid GUID values for the duration of the call. `object` must point to writable storage for one COM interface
+/// pointer. On success, the caller owns one reference and must release it with `IUnknown::Release`.
+#[unsafe(no_mangle)]
+pub unsafe extern "system" fn DllGetClassObject(
+    clsid: *const GUID,
+    riid: *const GUID,
+    object: *mut *mut c_void,
+) -> HRESULT {
+    if clsid.is_null() || object.is_null() {
+        return E_POINTER;
+    }
+
+    // SAFETY: clsid is non-null and points to a GUID provided by the COM caller.
+    let requested_clsid = unsafe { *clsid };
+    if !guid_eq(&requested_clsid, &CLSID_PACKAGE_MANAGER) {
+        // SAFETY: object is non-null and should be cleared on failure.
+        unsafe {
+            *object = ptr::null_mut();
+        }
+        return CLASS_E_CLASSNOTAVAILABLE;
+    }
+
+    let factory = Box::new(ClassFactoryObject::new());
+    let raw = Box::into_raw(factory);
+    // SAFETY: raw is a newly allocated ClassFactoryObject with a valid vtable.
+    let hr = unsafe { class_factory_query_interface(raw.cast::<c_void>(), riid, object) };
+    // SAFETY: Release balances the initial reference held by raw; successful QueryInterface has added caller's ref.
+    unsafe {
+        class_factory_release(raw.cast::<c_void>());
+    }
+
+    hr
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn DllCanUnloadNow() -> HRESULT {
+    if ACTIVE_OBJECTS.load(Ordering::Acquire) == 0 && SERVER_LOCKS.load(Ordering::Acquire) == 0 {
+        S_OK
+    } else {
+        S_FALSE
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn PingetPackageManagerClsid() -> GUID {
+    CLSID_PACKAGE_MANAGER
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn PingetPackageManagerIid() -> GUID {
+    IID_IPACKAGE_MANAGER
+}

--- a/rust/crates/pinget-core/Cargo.toml
+++ b/rust/crates/pinget-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinget-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Pure Rust Pinget core library that works directly with source caches, REST endpoints, and installed package state without COM."
 license = "MIT"

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -4,6 +4,8 @@ use std::fmt::{Display, Formatter};
 use std::fs;
 use std::io::{Cursor, Read};
 #[cfg(windows)]
+use std::mem::{MaybeUninit, size_of};
+#[cfg(windows)]
 use std::os::windows::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
@@ -1576,24 +1578,32 @@ impl Repository {
                 continue;
             }
 
-            let mut dependency_request = InstallRequest::new(PackageQuery {
-                id: Some(dependency_id),
-                source: request
-                    .dependency_source
-                    .clone()
-                    .or_else(|| request.query.source.clone()),
-                exact: true,
-                ..PackageQuery::default()
-            });
-            dependency_request.mode = request.mode;
-            dependency_request.accept_package_agreements = request.accept_package_agreements;
-            dependency_request.force = request.force;
-            dependency_request.ignore_security_hash = request.ignore_security_hash;
-            dependency_request.dependency_source = request.dependency_source.clone();
+            let dependency_request = Self::create_dependency_install_request(dependency_id, request);
             self.install_request(&dependency_request)?;
         }
 
         Ok(())
+    }
+
+    fn create_dependency_install_request(dependency_id: String, request: &InstallRequest) -> InstallRequest {
+        let mut dependency_request = InstallRequest::new(PackageQuery {
+            id: Some(dependency_id),
+            source: request
+                .dependency_source
+                .clone()
+                .or_else(|| request.query.source.clone()),
+            exact: true,
+            ..PackageQuery::default()
+        });
+        dependency_request.mode = match request.mode {
+            InstallerMode::Interactive => InstallerMode::Interactive,
+            InstallerMode::SilentWithProgress | InstallerMode::Silent => InstallerMode::Silent,
+        };
+        dependency_request.accept_package_agreements = request.accept_package_agreements;
+        dependency_request.no_upgrade = true;
+        dependency_request.ignore_security_hash = request.ignore_security_hash;
+        dependency_request.dependency_source = request.dependency_source.clone();
+        dependency_request
     }
 
     fn create_repair_list_query(request: &RepairRequest) -> ListQuery {
@@ -2977,6 +2987,10 @@ fn ensure_app_dirs(app_root: &Path) -> Result<()> {
 }
 
 fn default_app_root() -> Result<PathBuf> {
+    if let Some(app_root) = std::env::var_os("PINGET_APPROOT") {
+        return Ok(PathBuf::from(app_root));
+    }
+
     let local_app_data = dirs::data_local_dir().ok_or_else(|| anyhow!("unable to determine LocalAppData path"))?;
 
     #[cfg(windows)]
@@ -3760,50 +3774,61 @@ fn packaged_secure_settings_root() -> Result<PathBuf> {
 #[cfg(windows)]
 #[allow(clippy::multiple_unsafe_ops_per_block)]
 fn current_user_sid() -> Result<String> {
+    fn close_token(token: HANDLE) {
+        if !token.is_null() {
+            // SAFETY: token is a HANDLE returned by OpenProcessToken and may be closed once here.
+            unsafe {
+                CloseHandle(token);
+            }
+        }
+    }
+
     let mut token: HANDLE = std::ptr::null_mut();
-    // SAFETY: GetCurrentProcess returns a pseudo-handle for the current process and does not require ownership.
+    // SAFETY: GetCurrentProcess returns a pseudo-handle valid for OpenProcessToken in this process.
     let current_process = unsafe { GetCurrentProcess() };
-    // SAFETY: token points to writable storage for the handle returned by OpenProcessToken.
+    // SAFETY: token points to valid storage for the process token handle on success.
     if unsafe { OpenProcessToken(current_process, TOKEN_QUERY, &mut token) } == 0 {
         bail!("failed to open current process token")
     }
 
     let mut length = 0;
-    // SAFETY: This size probe intentionally passes a null buffer with zero length.
-    unsafe { GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut length) };
-    let word_count = (length as usize).div_ceil(size_of::<usize>());
-    let mut buffer = vec![0usize; word_count];
-    // SAFETY: buffer is writable, sufficiently large according to the prior size probe, and suitably aligned.
-    if unsafe { GetTokenInformation(token, TokenUser, buffer.as_mut_ptr() as *mut _, length, &mut length) } == 0 {
-        // SAFETY: token was returned by OpenProcessToken and is still owned by this function.
-        unsafe { CloseHandle(token) };
+    // SAFETY: The null buffer call asks Windows for the required buffer length.
+    unsafe {
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut length);
+    }
+
+    let element_size = size_of::<TOKEN_USER>();
+    let element_count = (length as usize).div_ceil(element_size);
+    let mut buffer = vec![MaybeUninit::<TOKEN_USER>::uninit(); element_count];
+    // SAFETY: buffer is aligned for TOKEN_USER and has at least length bytes of storage.
+    if unsafe { GetTokenInformation(token, TokenUser, buffer.as_mut_ptr().cast(), length, &mut length) } == 0 {
+        close_token(token);
         bail!("failed to get current user token information")
     }
 
-    // SAFETY: GetTokenInformation wrote a TOKEN_USER structure at the start of the aligned buffer.
-    let token_user = unsafe { &*(buffer.as_ptr() as *const TOKEN_USER) };
+    // SAFETY: GetTokenInformation initialized the buffer as a TOKEN_USER structure.
+    let token_user = unsafe { &*buffer.as_ptr().cast::<TOKEN_USER>() };
     let mut sid_ptr: *mut u16 = std::ptr::null_mut();
-    // SAFETY: token_user.User.Sid is provided by the OS, and sid_ptr receives a LocalAlloc buffer.
+    // SAFETY: token_user.User.Sid is supplied by Windows and sid_ptr receives a LocalAlloc buffer on success.
     if unsafe { ConvertSidToStringSidW(token_user.User.Sid, &mut sid_ptr) } == 0 {
-        // SAFETY: token was returned by OpenProcessToken and is still owned by this function.
-        unsafe { CloseHandle(token) };
+        close_token(token);
         bail!("failed to convert current user SID")
     }
 
     let mut len = 0usize;
-    // SAFETY: ConvertSidToStringSidW returns a null-terminated UTF-16 string.
-    while unsafe { *sid_ptr.add(len) } != 0 {
+    // SAFETY: sid_ptr is a null-terminated UTF-16 string returned by ConvertSidToStringSidW.
+    while unsafe { *sid_ptr.wrapping_add(len) } != 0 {
         len += 1;
     }
 
-    // SAFETY: sid_ptr is valid for len UTF-16 code units as measured above.
-    let sid = std::ffi::OsString::from_wide(unsafe { std::slice::from_raw_parts(sid_ptr, len) })
-        .to_string_lossy()
-        .into_owned();
+    // SAFETY: sid_ptr points to len initialized UTF-16 code units.
+    let sid_slice = unsafe { std::slice::from_raw_parts(sid_ptr, len) };
+    let sid = std::ffi::OsString::from_wide(sid_slice).to_string_lossy().into_owned();
     // SAFETY: sid_ptr was allocated by ConvertSidToStringSidW and must be released with LocalFree.
-    unsafe { LocalFree(sid_ptr.cast()) };
-    // SAFETY: token was returned by OpenProcessToken and has not yet been closed.
-    unsafe { CloseHandle(token) };
+    unsafe {
+        LocalFree(sid_ptr.cast());
+    }
+    close_token(token);
     Ok(sid)
 }
 
@@ -6665,6 +6690,30 @@ mod tests {
 
         assert_eq!(options.app_root, PathBuf::from(r"C:\temp\pinget-test"));
         assert_eq!(options.user_agent, "pinget-rs-tests/1.0");
+    }
+
+    #[test]
+    fn dependency_install_requests_are_silent_and_not_forced() {
+        let mut parent = InstallRequest::new(PackageQuery {
+            source: Some("winget".to_owned()),
+            ..PackageQuery::default()
+        });
+        parent.mode = InstallerMode::SilentWithProgress;
+        parent.force = true;
+        parent.accept_package_agreements = true;
+        parent.ignore_security_hash = true;
+        parent.dependency_source = Some("dependencies".to_owned());
+
+        let dependency =
+            Repository::create_dependency_install_request("Microsoft.VCRedist.2015+.x64".to_owned(), &parent);
+
+        assert_eq!(dependency.query.id.as_deref(), Some("Microsoft.VCRedist.2015+.x64"));
+        assert_eq!(dependency.query.source.as_deref(), Some("dependencies"));
+        assert_eq!(dependency.mode, InstallerMode::Silent);
+        assert!(!dependency.force);
+        assert!(dependency.no_upgrade);
+        assert!(dependency.accept_package_agreements);
+        assert!(dependency.ignore_security_hash);
     }
 
     #[test]

--- a/scripts/Build-PowerShellModule.ps1
+++ b/scripts/Build-PowerShellModule.ps1
@@ -2,32 +2,180 @@
 param(
     [string]$Configuration = 'Release',
     [string]$Framework = 'net8.0',
+    [string]$DesktopFramework = 'net48',
     [string]$Version,
     [string]$OutputRoot = (Join-Path $PSScriptRoot '..\dist\powershell-module'),
     [string]$ArchivePath,
+    [ValidateSet('win-x64', 'win-arm64')]
+    [string[]]$NativeComRuntimeIdentifiers = @(),
     [switch]$NoBuild,
-    [switch]$Clean
+    [switch]$Clean,
+    [switch]$SkipWindowsPowerShell
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $moduleName = 'Devolutions.Pinget.Client'
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $projectPath = Join-Path $PSScriptRoot '..\dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\Devolutions.Pinget.PowerShell.Cmdlets.csproj'
-$buildOutput = Join-Path $PSScriptRoot "..\dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\bin\$Configuration\$Framework"
+$moduleFilesRoot = Join-Path $PSScriptRoot '..\dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\ModuleFiles'
+$coreBuildOutput = Join-Path $PSScriptRoot "..\dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\bin\$Configuration\$Framework"
+$desktopBuildOutput = Join-Path $PSScriptRoot "..\dotnet\src\Devolutions.Pinget.PowerShell.Cmdlets\bin\$Configuration\$DesktopFramework"
 $moduleRoot = Join-Path $OutputRoot $moduleName
 $moduleManifest = Join-Path $moduleRoot "$moduleName.psd1"
+$nativeComCargoDllName = 'pinget_com.dll'
+$nativeComPackageDllName = 'pinget-com.dll'
+$coreRuntimeIdentifiersToKeep = @(
+    'linux-x64',
+    'linux-arm64',
+    'osx-x64',
+    'osx-arm64',
+    'win-x64',
+    'win-arm64'
+)
+$allNativeComTargets = @(
+    @{
+        Rid = 'win-x64'
+        CargoTarget = 'x86_64-pc-windows-msvc'
+    },
+    @{
+        Rid = 'win-arm64'
+        CargoTarget = 'aarch64-pc-windows-msvc'
+    }
+)
 
-if (-not $NoBuild) {
-    dotnet build $projectPath -c $Configuration -f $Framework
-    if ($LASTEXITCODE -ne 0) {
-        throw "dotnet build failed with exit code $LASTEXITCODE."
+function Test-CiBuild {
+    return -not [string]::IsNullOrWhiteSpace($env:CI) -or
+        -not [string]::IsNullOrWhiteSpace($env:GITHUB_ACTIONS) -or
+        -not [string]::IsNullOrWhiteSpace($env:TF_BUILD)
+}
+
+function Get-CurrentWindowsRuntimeIdentifier {
+    switch ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture) {
+        'X64' { return 'win-x64' }
+        'Arm64' { return 'win-arm64' }
+        default {
+            throw "Native COM packaging is only supported for x64 and ARM64 Windows processes. Current process architecture: $([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)."
+        }
     }
 }
 
-$builtManifest = Join-Path $buildOutput "$moduleName.psd1"
-if (-not (Test-Path -Path $builtManifest)) {
-    throw "PowerShell module manifest not found: $builtManifest"
+function Resolve-NativeComTargets {
+    param(
+        [string[]]$RequestedRuntimeIdentifiers
+    )
+
+    if ($RequestedRuntimeIdentifiers.Count -eq 0) {
+        if (Test-CiBuild) {
+            $RequestedRuntimeIdentifiers = @('win-x64', 'win-arm64')
+        }
+        else {
+            $RequestedRuntimeIdentifiers = @(Get-CurrentWindowsRuntimeIdentifier)
+        }
+    }
+
+    $resolvedTargets = @($allNativeComTargets | Where-Object { $RequestedRuntimeIdentifiers -contains $_.Rid })
+    if ($resolvedTargets.Count -ne $RequestedRuntimeIdentifiers.Count) {
+        throw "Unsupported native COM runtime identifier requested. Supported values: win-x64, win-arm64."
+    }
+
+    return $resolvedTargets
+}
+
+function Remove-UnusedRuntimeAssets {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Root,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$RuntimeIdentifiersToKeep
+    )
+
+    $runtimesRoot = Join-Path $Root 'runtimes'
+    if (-not (Test-Path -Path $runtimesRoot)) {
+        return
+    }
+
+    Get-ChildItem -Path $runtimesRoot -Directory |
+        Where-Object { $RuntimeIdentifiersToKeep -notcontains $_.Name } |
+        Remove-Item -Recurse -Force
+}
+
+function Build-NativeComDll {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CargoTarget
+    )
+
+    cargo build -p pinget-com --manifest-path (Join-Path $repoRoot 'rust\Cargo.toml') --release --target $CargoTarget
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo build failed for pinget-com target $CargoTarget with exit code $LASTEXITCODE."
+    }
+}
+
+function Get-NativeComDllPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CargoTarget
+    )
+
+    $releaseNativeComDll = Join-Path $repoRoot "rust\target\$CargoTarget\release\$nativeComCargoDllName"
+    if (Test-Path -Path $releaseNativeComDll) {
+        return $releaseNativeComDll
+    }
+
+    $debugNativeComDll = Join-Path $repoRoot "rust\target\$CargoTarget\debug\$nativeComCargoDllName"
+    if (Test-Path -Path $debugNativeComDll) {
+        return $debugNativeComDll
+    }
+
+    if ($CargoTarget -eq 'x86_64-pc-windows-msvc') {
+        $legacyReleaseNativeComDll = Join-Path $repoRoot "rust\target\release\$nativeComCargoDllName"
+        if (Test-Path -Path $legacyReleaseNativeComDll) {
+            return $legacyReleaseNativeComDll
+        }
+
+        $legacyDebugNativeComDll = Join-Path $repoRoot "rust\target\debug\$nativeComCargoDllName"
+        if (Test-Path -Path $legacyDebugNativeComDll) {
+            return $legacyDebugNativeComDll
+        }
+    }
+
+    throw "Native COM DLL not found for target $CargoTarget."
+}
+
+$nativeComTargets = @(Resolve-NativeComTargets -RequestedRuntimeIdentifiers $NativeComRuntimeIdentifiers)
+$desktopRuntimeIdentifiersToKeep = @($nativeComTargets | ForEach-Object { $_.Rid })
+
+if (-not $NoBuild) {
+    dotnet build $projectPath -c $Configuration -f $Framework --tl:off
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet build failed for $Framework with exit code $LASTEXITCODE."
+    }
+
+    if (-not $SkipWindowsPowerShell) {
+        dotnet build $projectPath -c $Configuration -f $DesktopFramework --tl:off
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet build failed for $DesktopFramework with exit code $LASTEXITCODE."
+        }
+
+        if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+            foreach ($nativeComTarget in $nativeComTargets) {
+                Build-NativeComDll -CargoTarget $nativeComTarget.CargoTarget
+            }
+        }
+    }
+}
+
+$sourceManifest = Join-Path $moduleFilesRoot "$moduleName.psd1"
+if (-not (Test-Path -Path $sourceManifest)) {
+    throw "PowerShell module manifest not found: $sourceManifest"
+}
+
+$sourceLoader = Join-Path $moduleFilesRoot "$moduleName.psm1"
+if (-not (Test-Path -Path $sourceLoader)) {
+    throw "PowerShell module loader not found: $sourceLoader"
 }
 
 if ($Clean -and (Test-Path -Path $OutputRoot)) {
@@ -35,10 +183,30 @@ if ($Clean -and (Test-Path -Path $OutputRoot)) {
 }
 
 New-Item -Path $moduleRoot -ItemType Directory -Force | Out-Null
-Copy-Item -Path (Join-Path $buildOutput '*') -Destination $moduleRoot -Recurse -Force
-Get-ChildItem -Path $moduleRoot -Filter '*.psd1' |
-    Where-Object { $_.Name -ne "$moduleName.psd1" } |
+Copy-Item -Path (Join-Path $moduleFilesRoot '*') -Destination $moduleRoot -Recurse -Force
+
+$coreModuleRoot = Join-Path $moduleRoot "Core\$Framework"
+New-Item -Path $coreModuleRoot -ItemType Directory -Force | Out-Null
+Copy-Item -Path (Join-Path $coreBuildOutput '*') -Destination $coreModuleRoot -Recurse -Force
+Get-ChildItem -Path $coreModuleRoot -Include '*.psd1', '*.psm1', 'Format.ps1xml' -Recurse |
     Remove-Item -Force
+Remove-UnusedRuntimeAssets -Root $coreModuleRoot -RuntimeIdentifiersToKeep $coreRuntimeIdentifiersToKeep
+
+if (-not $SkipWindowsPowerShell) {
+    $desktopModuleRoot = Join-Path $moduleRoot "Desktop\$DesktopFramework"
+    New-Item -Path $desktopModuleRoot -ItemType Directory -Force | Out-Null
+    Copy-Item -Path (Join-Path $desktopBuildOutput '*') -Destination $desktopModuleRoot -Recurse -Force
+    Get-ChildItem -Path $desktopModuleRoot -Include '*.psd1', '*.psm1', 'Format.ps1xml' -Recurse |
+        Remove-Item -Force
+    Remove-UnusedRuntimeAssets -Root $desktopModuleRoot -RuntimeIdentifiersToKeep $desktopRuntimeIdentifiersToKeep
+
+    foreach ($nativeComTarget in $nativeComTargets) {
+        $nativeComDllPath = Get-NativeComDllPath -CargoTarget $nativeComTarget.CargoTarget
+        $nativeComDestination = Join-Path $desktopModuleRoot "runtimes\$($nativeComTarget.Rid)\native"
+        New-Item -Path $nativeComDestination -ItemType Directory -Force | Out-Null
+        Copy-Item -Path $nativeComDllPath -Destination (Join-Path $nativeComDestination $nativeComPackageDllName) -Force
+    }
+}
 
 if (-not [string]::IsNullOrWhiteSpace($Version)) {
     if ($Version -notmatch '^([0-9]+(?:\.[0-9]+){1,3})(?:-.+)?$') {
@@ -56,8 +224,8 @@ if ($manifestInfo.Name -ne $moduleName) {
     throw "Expected module '$moduleName' but manifest resolved to '$($manifestInfo.Name)'."
 }
 
-if ($manifestInfo.PowerShellVersion -lt [version]'7.4.0') {
-    throw "Expected the module to require PowerShell 7.4.0 or newer."
+if ($manifestInfo.PowerShellVersion -lt [version]'5.1') {
+    throw "Expected the module to require PowerShell 5.1 or newer."
 }
 
 if (-not [string]::IsNullOrWhiteSpace($ArchivePath)) {

--- a/scripts/Set-PingetVersion.ps1
+++ b/scripts/Set-PingetVersion.ps1
@@ -61,6 +61,11 @@ Set-VersionInFile `
     -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
 
 Set-VersionInFile `
+    -RelativePath 'rust\crates\pinget-com\Cargo.toml' `
+    -Pattern '^(version\s*=\s*")[^"]+(")' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-VersionInFile `
     -RelativePath 'dotnet\src\Devolutions.Pinget.Cli\Program.cs' `
     -Pattern '^(const string Version\s*=\s*")[^"]+(";)' `
     -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }


### PR DESCRIPTION
## Summary
- Add a Windows-only `pinget-com` Rust native COM bridge backed by `pinget-core`.
- Add a `net48` C# COM interop layer and Windows PowerShell module path while keeping PowerShell 7 on the pure .NET stack.
- Package Desktop/Core module layouts, trim SQLite runtime assets, and place `pinget-com.dll` under `Desktop\net48\runtimes\win-*\native`.
- Align dependency install behavior so dependencies are not forced and use silent/no-upgrade semantics.
- Bump Pinget version metadata to `0.2.0` and include `pinget-com` in the version bump script.

## Validation
- `dotnet build dotnet\Devolutions.Pinget.slnx -c Release`
- `pinget.exe --version` -> `pinget v0.2.0`
- `cargo check -p pinget-cli`
- `cargo check -p pinget-com`
- Windows PowerShell Pester suite: 13/13 passed
- PowerShell 7 Pester suite: 13/13 passed

## Workflow runs
- CI: https://github.com/Devolutions/pinget/actions/runs/25072366156
- Parity Test: https://github.com/Devolutions/pinget/actions/runs/25072367766
- Release dry-run: https://github.com/Devolutions/pinget/actions/runs/25072369345