### PR TITLE
Improve embedded show diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,19 @@ The **`Devolutions.Pinget.Core`** library is available on [nuget.org](https://ww
 dotnet add package Devolutions.Pinget.Core
 ```
 
-The package targets .NET 8 and .NET 10. `Repository.Open()` is the main entry point; pass `RepositoryOptions` when you want an isolated app root or a custom user agent.
+The package targets .NET 8 and .NET 10. `Repository.Open()` is the main entry point; pass `RepositoryOptions` when you want source diagnostics, an isolated app root, or a custom user agent.
+
+`RepositoryOptions.AppRoot = null` is the system WinGet mode on Windows. It uses the real Desktop App Installer / WinGet source state and is intended for embedded apps that need to align with `winget.exe source list` and `winget source export`. Use a custom app root when you want isolated sources and caches for tests, probes, or app-private package catalogs.
 
 ```csharp
 using Devolutions.Pinget.Core;
 
+var diagnostics = new List<RepositoryWarning>();
 using var repository = Repository.Open(new RepositoryOptions
 {
-    AppRoot = Path.Combine(Path.GetTempPath(), "pinget-sample"),
+    AppRoot = null,
     UserAgent = "my-app/1.0",
+    Diagnostics = diagnostics.Add,
 });
 
 foreach (var update in repository.UpdateSources())
@@ -162,6 +166,11 @@ var rdm = repository.Show(new PackageQuery
 
 Console.WriteLine($"{rdm.Manifest.Name} {rdm.Manifest.Version}");
 
+var serializable = rdm.ToSerializableManifest();
+var json = System.Text.Json.JsonSerializer.Serialize(
+    serializable,
+    PingetJsonContext.Default.SerializableShowManifest);
+
 var (_, installerPath) = repository.DownloadInstaller(
     new PackageQuery
     {
@@ -172,6 +181,10 @@ var (_, installerPath) = repository.DownloadInstaller(
 
 Console.WriteLine(installerPath);
 ```
+
+For embedded `show` and exact package resolution, Core exposes structured diagnostics in result `SourceWarnings`, in `SourceSearchException.Warning`, and through `RepositoryOptions.Diagnostics`. Single-source search failures surface the source name, source kind, source URL, cache path, HTTP status when available, and the original exception message instead of looking like a clean no-match. Multiple-source ambiguity is exposed as `MultiplePackageMatchesException.Matches`, so callers do not need to parse source names out of exception text.
+
+`Repository.ShowManifest(query)` and `ShowResult.ToSerializableManifest()` return the same serializable manifest model used by the C# CLI `show --output json|yaml` path, including all installers and the Core-selected installer. Use `PingetJsonContext` for reflection-free `System.Text.Json` serialization in hosts that set `JsonSerializer.IsReflectionEnabledByDefault` to `false`.
 
 ## Non-goals
 

--- a/dotnet/src/Devolutions.Pinget.Cli/Program.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/Program.cs
@@ -136,7 +136,7 @@ showCommand.SetHandler((ctx) =>
     else
     {
         var result = repo.Show(query);
-        if (output != OutputFormat.Text) WriteManifestStructuredOutput(result.ToStructuredDocument(), output);
+        if (output != OutputFormat.Text) WriteManifestStructuredOutput(result.ToSerializableManifest(), output);
         else PrintShow(result);
     }
 });
@@ -1266,7 +1266,10 @@ void WriteStructuredOutput(object value, OutputFormat output)
     switch (output)
     {
         case OutputFormat.Json:
-            Console.WriteLine(JsonSerializer.Serialize(value, JsonOpts));
+            if (value is SerializableShowManifest showManifest)
+                Console.WriteLine(JsonSerializer.Serialize(showManifest, PingetJsonContext.Default.SerializableShowManifest));
+            else
+                Console.WriteLine(JsonSerializer.Serialize(value, JsonOpts));
             break;
         case OutputFormat.Yaml:
             Console.Write(new SerializerBuilder().Build().Serialize(value));

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using Microsoft.Data.Sqlite;
 using System.Net;
 using System.Net.Sockets;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Xunit;
 using Devolutions.Pinget.Core;
@@ -1497,6 +1499,289 @@ public class RepositoryParityTests
     }
 }
 
+public class RepositoryEmbeddingTests
+{
+    private const string TesslPackageId = "tessl.tessl";
+
+    [Fact]
+    public void ShowManifest_RestExactId_ReturnsSerializableManifestAndSelectedInstaller()
+    {
+        using var server = new TestRestSourceServer();
+        var diagnostics = new List<RepositoryWarning>();
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                Diagnostics = diagnostics.Add,
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.Rest));
+
+            var result = repo.ShowManifest(new PackageQuery
+            {
+                Id = TesslPackageId,
+                Exact = true,
+                Source = "test",
+                InstallerArchitecture = "x64",
+            });
+
+            Assert.Equal(TesslPackageId, result.PackageIdentifier);
+            Assert.Equal("Tessl", result.PackageName);
+            Assert.Equal("1.2.3", result.PackageVersion);
+            Assert.Equal("test", result.SourceName);
+            Assert.Equal(SourceKind.Rest, result.SourceKind);
+            Assert.Equal("Tessl Publisher", result.Publisher);
+            Assert.Equal("Tessl Author", result.Author);
+            Assert.Equal("Tessl short description", result.ShortDescription);
+            Assert.Equal("https://example.test/tessl", result.PackageUrl);
+            Assert.Equal("MIT", result.License);
+            Assert.Equal("https://example.test/license", result.LicenseUrl);
+            Assert.Equal("Release notes", result.ReleaseNotes);
+            Assert.Equal("https://example.test/release-notes", result.ReleaseNotesUrl);
+            Assert.Equal(["ai", "cli"], result.Tags);
+            Assert.Equal(["Contoso.Dependency"], result.PackageDependencies);
+            var installer = Assert.Single(result.Installers);
+            Assert.Equal("https://example.test/tessl.exe", installer.InstallerUrl);
+            Assert.Equal(new string('A', 64), installer.InstallerSha256);
+            Assert.Equal("exe", installer.InstallerType);
+            Assert.Equal("2026-01-02", installer.ReleaseDate);
+            Assert.NotNull(result.SelectedInstaller);
+            Assert.Equal(installer.InstallerUrl, result.SelectedInstaller!.InstallerUrl);
+            Assert.Equal(["Installer.Dependency"], installer.PackageDependencies);
+            Assert.Empty(result.SourceWarnings);
+            Assert.Empty(diagnostics);
+
+            var json = JsonSerializer.Serialize(result, PingetJsonContext.Default.SerializableShowManifest);
+            using var document = JsonDocument.Parse(json);
+            Assert.Equal(TesslPackageId, document.RootElement.GetProperty(nameof(SerializableShowManifest.PackageIdentifier)).GetString());
+            Assert.Equal("https://example.test/tessl.exe",
+                document.RootElement.GetProperty(nameof(SerializableShowManifest.SelectedInstaller)).GetProperty(nameof(SerializableInstaller.InstallerUrl)).GetString());
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_SingleRestSourceFailure_ThrowsSourceSearchExceptionWithDiagnostics()
+    {
+        using var server = new TestRestSourceServer(request =>
+            request.Url?.AbsolutePath == "/manifestSearch"
+                ? new TestRestResponse(503, """{"error":"source unavailable"}""")
+                : TestRestSourceServer.DefaultResponse(request));
+
+        var diagnostics = new List<RepositoryWarning>();
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                Diagnostics = diagnostics.Add,
+            });
+            ReplaceSources(repo, ("winget.pro", server.Url, SourceKind.Rest));
+
+            var ex = Assert.Throws<SourceSearchException>(() => repo.Show(new PackageQuery
+            {
+                Id = TesslPackageId,
+                Exact = true,
+                Source = "winget.pro",
+            }));
+
+            Assert.Equal("winget.pro", ex.Warning.SourceName);
+            Assert.Equal(SourceKind.Rest, ex.Warning.SourceKind);
+            Assert.Equal(503, ex.Warning.HttpStatusCode);
+            Assert.Contains("/manifestSearch", ex.Warning.RequestUri);
+            Assert.Contains("503", ex.Warning.Message);
+            var diagnostic = Assert.Single(diagnostics);
+            Assert.Equal(ex.Warning.SourceName, diagnostic.SourceName);
+            Assert.Equal(ex.Warning.HttpStatusCode, diagnostic.HttpStatusCode);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_MultipleSourcesExposeStructuredMatches()
+    {
+        using var firstServer = new TestRestSourceServer();
+        using var secondServer = new TestRestSourceServer();
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions { AppRoot = appRoot });
+            ReplaceSources(
+                repo,
+                ("first", firstServer.Url, SourceKind.Rest),
+                ("second", secondServer.Url, SourceKind.Rest));
+
+            var ex = Assert.Throws<MultiplePackageMatchesException>(() => repo.Show(new PackageQuery
+            {
+                Id = TesslPackageId,
+                Exact = true,
+            }));
+
+            Assert.Equal(["first", "second"], ex.Matches.Select(match => match.SourceName).ToArray());
+            Assert.All(ex.Matches, match =>
+            {
+                Assert.Equal(TesslPackageId, match.Id);
+                Assert.Equal(SourceKind.Rest, match.SourceKind);
+            });
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void CliShowJson_MatchesCoreSerializableManifestForRestSource()
+    {
+        using var server = new TestRestSourceServer();
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using (var repo = Repository.Open(new RepositoryOptions { AppRoot = appRoot }))
+            {
+                ReplaceSources(repo, ("test", server.Url, SourceKind.Rest));
+                var core = repo.ShowManifest(new PackageQuery
+                {
+                    Id = TesslPackageId,
+                    Exact = true,
+                    Source = "test",
+                    InstallerArchitecture = "x64",
+                });
+
+                var cli = RunCliShowJson(appRoot);
+
+                Assert.Equal(core.PackageIdentifier, cli.RootElement.GetProperty(nameof(SerializableShowManifest.PackageIdentifier)).GetString());
+                Assert.Equal(core.SourceName, cli.RootElement.GetProperty(nameof(SerializableShowManifest.SourceName)).GetString());
+                Assert.Equal(core.SelectedInstaller!.InstallerUrl,
+                    cli.RootElement.GetProperty(nameof(SerializableShowManifest.SelectedInstaller)).GetProperty(nameof(SerializableInstaller.InstallerUrl)).GetString());
+                Assert.Equal(core.PackageDependencies,
+                    cli.RootElement.GetProperty(nameof(SerializableShowManifest.PackageDependencies)).EnumerateArray().Select(item => item.GetString() ?? "").ToList());
+            }
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [SkippableFact]
+    public void LiveWingetPro_TesslExactLookup_ReturnsManifestWhenAvailable()
+    {
+        const string liveSourceUrl = "https://api.winget.pro/4259fd23-6fcd-46bf-9287-be8833cfbdd5";
+        Skip.IfNot(string.Equals(Environment.GetEnvironmentVariable("PINGET_LIVE_WINGETPRO_TESTS"), "1", StringComparison.Ordinal),
+            "Set PINGET_LIVE_WINGETPRO_TESTS=1 to run the optional winget.pro live smoke test.");
+
+        using var probe = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        try
+        {
+            using var response = probe.GetAsync($"{liveSourceUrl}/information").GetAwaiter().GetResult();
+            Skip.If(!response.IsSuccessStatusCode, $"winget.pro information endpoint returned {(int)response.StatusCode}.");
+        }
+        catch (Exception ex)
+        {
+            Skip.If(true, $"winget.pro is unavailable: {ex.Message}");
+        }
+
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions { AppRoot = appRoot });
+            ReplaceSources(repo, ("winget.pro", liveSourceUrl, SourceKind.Rest));
+
+            var result = repo.ShowManifest(new PackageQuery
+            {
+                Id = TesslPackageId,
+                Exact = true,
+                Source = "winget.pro",
+            });
+
+            Assert.Equal(TesslPackageId, result.PackageIdentifier, ignoreCase: true);
+            Assert.Equal("winget.pro", result.SourceName);
+            Assert.NotEmpty(result.Installers);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    private static void ReplaceSources(Repository repo, params (string Name, string Arg, SourceKind Kind)[] sources)
+    {
+        foreach (var source in repo.ListSources())
+            repo.RemoveSource(source.Name);
+
+        foreach (var source in sources)
+            repo.AddSource(source.Name, source.Arg, source.Kind, trustLevel: "trusted");
+    }
+
+    private static JsonDocument RunCliShowJson(string appRoot)
+    {
+        var root = FindRepositoryRoot();
+        var cliProject = Path.Combine(root, "dotnet", "src", "Devolutions.Pinget.Cli", "Devolutions.Pinget.Cli.csproj");
+        var cliDll = Path.Combine(root, "dotnet", "src", "Devolutions.Pinget.Cli", "bin", "Release", "net10.0", "pinget.dll");
+
+        var build = RunProcess("dotnet", ["build", cliProject, "-c", "Release", "-v:q"], appRoot);
+        Assert.Equal(0, build.ExitCode);
+        Assert.True(File.Exists(cliDll));
+
+        var run = RunProcess("dotnet",
+        [
+            cliDll,
+            "show",
+            "--id", TesslPackageId,
+            "--exact",
+            "--source", "test",
+            "--architecture", "x64",
+            "--output", "json",
+        ], appRoot);
+
+        Assert.Equal(0, run.ExitCode);
+        return JsonDocument.Parse(run.Stdout);
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunProcess(string fileName, IReadOnlyList<string> arguments, string appRoot)
+    {
+        var psi = new ProcessStartInfo(fileName)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        psi.Environment["PINGET_APPROOT"] = appRoot;
+
+        foreach (var argument in arguments)
+            psi.ArgumentList.Add(argument);
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException($"Failed to start {fileName}.");
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        return (process.ExitCode, stdout.GetAwaiter().GetResult(), stderr.GetAwaiter().GetResult());
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "dotnet", "Devolutions.Pinget.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
+    }
+}
+
 file static class TestPaths
 {
     public static string CreateTempAppRoot() =>
@@ -1514,6 +1799,170 @@ file static class TestPaths
     {
         if (Directory.Exists(appRoot))
             Directory.Delete(appRoot, recursive: true);
+    }
+}
+
+file sealed record TestRestResponse(int StatusCode, string Body, string ContentType = "application/json");
+
+file sealed class TestRestSourceServer : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly Task _loopTask;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Func<HttpListenerRequest, TestRestResponse> _handler;
+
+    public TestRestSourceServer(Func<HttpListenerRequest, TestRestResponse>? handler = null)
+    {
+        _handler = handler ?? DefaultResponse;
+        var port = GetFreePort();
+        Url = $"http://127.0.0.1:{port}";
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"{Url}/");
+        _listener.Start();
+        _loopTask = Task.Run(async () =>
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                HttpListenerContext? context = null;
+                try
+                {
+                    context = await _listener.GetContextAsync();
+                    var response = _handler(context.Request);
+                    var bytes = System.Text.Encoding.UTF8.GetBytes(response.Body);
+                    context.Response.StatusCode = response.StatusCode;
+                    context.Response.ContentType = response.ContentType;
+                    context.Response.ContentLength64 = bytes.Length;
+                    await context.Response.OutputStream.WriteAsync(bytes, _cts.Token);
+                }
+                catch (ObjectDisposedException) when (_cts.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (HttpListenerException) when (_cts.IsCancellationRequested)
+                {
+                    break;
+                }
+                finally
+                {
+                    context?.Response.OutputStream.Dispose();
+                    context?.Response.Close();
+                }
+            }
+        }, _cts.Token);
+    }
+
+    public string Url { get; }
+
+    public static TestRestResponse DefaultResponse(HttpListenerRequest request)
+    {
+        return request.Url?.AbsolutePath switch
+        {
+            "/information" => new TestRestResponse(200, """
+                {
+                  "Data": {
+                    "SourceIdentifier": "Test.Rest",
+                    "ServerSupportedVersions": [ "1.10.0" ],
+                    "RequiredPackageMatchFields": [],
+                    "UnsupportedPackageMatchFields": []
+                  }
+                }
+                """),
+            "/manifestSearch" => new TestRestResponse(200, """
+                {
+                  "Data": [
+                    {
+                      "PackageIdentifier": "tessl.tessl",
+                      "PackageName": "Tessl",
+                      "Versions": [
+                        { "PackageVersion": "1.2.3", "Channel": "" }
+                      ]
+                    }
+                  ]
+                }
+                """),
+            "/packageManifests/tessl.tessl" => new TestRestResponse(200, $$"""
+                {
+                  "Data": {
+                    "PackageIdentifier": "tessl.tessl",
+                    "PackageName": "Tessl",
+                    "DefaultLocale": {
+                      "PackageName": "Tessl",
+                      "Publisher": "Tessl Publisher",
+                      "Author": "Tessl Author",
+                      "ShortDescription": "Tessl short description",
+                      "Description": "Tessl long description",
+                      "PackageUrl": "https://example.test/tessl",
+                      "License": "MIT",
+                      "LicenseUrl": "https://example.test/license",
+                      "ReleaseNotes": "Release notes",
+                      "ReleaseNotesUrl": "https://example.test/release-notes",
+                      "Tags": [ "ai", "cli" ]
+                    },
+                    "Versions": [
+                      {
+                        "PackageVersion": "1.2.3",
+                        "DefaultLocale": {
+                          "PackageName": "Tessl",
+                          "Publisher": "Tessl Publisher",
+                          "Author": "Tessl Author",
+                          "ShortDescription": "Tessl short description",
+                          "Description": "Tessl long description",
+                          "PackageUrl": "https://example.test/tessl",
+                          "License": "MIT",
+                          "LicenseUrl": "https://example.test/license",
+                          "ReleaseNotes": "Release notes",
+                          "ReleaseNotesUrl": "https://example.test/release-notes",
+                          "Tags": [ "ai", "cli" ]
+                        },
+                        "Dependencies": {
+                          "PackageDependencies": [
+                            { "PackageIdentifier": "Contoso.Dependency" }
+                          ]
+                        },
+                        "Installers": [
+                          {
+                            "Architecture": "x64",
+                            "InstallerType": "exe",
+                            "InstallerUrl": "https://example.test/tessl.exe",
+                            "InstallerSha256": "{{new string('A', 64)}}",
+                            "ReleaseDate": "2026-01-02",
+                            "Dependencies": {
+                              "PackageDependencies": [
+                                { "PackageIdentifier": "Installer.Dependency" }
+                              ]
+                            }
+                          }
+                        ],
+                        "ManifestVersion": "1.10.0"
+                      }
+                    ],
+                    "ManifestVersion": "1.10.0"
+                  }
+                }
+                """),
+            _ => new TestRestResponse(404, """{"error":"not found"}"""),
+        };
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        _listener.Close();
+        try
+        {
+            _loopTask.GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
     }
 }
 

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/Devolutions.Pinget.Core.Tests.csproj
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/Devolutions.Pinget.Core.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="xunit" Version="2.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Devolutions.Pinget.Core\Devolutions.Pinget.Core.csproj" />

--- a/dotnet/src/Devolutions.Pinget.Core/Models.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Models.cs
@@ -34,8 +34,51 @@ public record SourceRecord
 /// </summary>
 public record RepositoryOptions
 {
+    /// <summary>
+    /// Storage root for source state and caches. A null value uses the real Desktop App Installer / WinGet state on Windows.
+    /// </summary>
     public string? AppRoot { get; init; }
     public string UserAgent { get; init; } = "pinget-dotnet/0.1";
+    public Action<RepositoryWarning>? Diagnostics { get; init; }
+}
+
+public record RepositoryWarning
+{
+    public required string Operation { get; init; }
+    public required string SourceName { get; init; }
+    public required SourceKind SourceKind { get; init; }
+    public required string SourceArg { get; init; }
+    public string? SourceIdentifier { get; init; }
+    public string? RequestUri { get; init; }
+    public string? CachePath { get; init; }
+    public required string Message { get; init; }
+    public string? ExceptionType { get; init; }
+    public int? HttpStatusCode { get; init; }
+}
+
+public class SourceSearchException : InvalidOperationException
+{
+    public SourceSearchException(RepositoryWarning warning, Exception innerException)
+        : base($"Failed during source operation '{warning.Operation}' for '{warning.SourceName}': {warning.Message}", innerException)
+    {
+        Warning = warning;
+    }
+
+    public RepositoryWarning Warning { get; }
+}
+
+public class MultiplePackageMatchesException : InvalidOperationException
+{
+    public MultiplePackageMatchesException(IEnumerable<SearchMatch> matches)
+        : base($"multiple packages matched: {FormatChoices(matches)}")
+    {
+        Matches = matches.ToList();
+    }
+
+    public IReadOnlyList<SearchMatch> Matches { get; }
+
+    private static string FormatChoices(IEnumerable<SearchMatch> matches) =>
+        string.Join(", ", matches.Take(10).Select(m => $"{m.Name} [{m.Id}] ({m.SourceName})"));
 }
 
 public record PackageQuery
@@ -94,6 +137,7 @@ public record SearchResponse
 {
     public required List<SearchMatch> Matches { get; init; }
     public required List<string> Warnings { get; init; }
+    public List<RepositoryWarning> SourceWarnings { get; init; } = [];
     public bool Truncated { get; init; }
 }
 
@@ -274,16 +318,142 @@ public record ShowResult
     public Installer? SelectedInstaller { get; init; }
     public List<string> CachedFiles { get; init; } = [];
     public List<string> Warnings { get; init; } = [];
+    public List<RepositoryWarning> SourceWarnings { get; init; } = [];
     public required object StructuredDocument { private get; init; }
 
     public object ToStructuredDocument() => StructuredOutput.CollapseManifestDocuments(StructuredDocument);
+
+    public SerializableShowManifest ToSerializableManifest()
+    {
+        var document = ToStructuredDocument() as Dictionary<string, object?> ??
+            new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+        string? GetString(string key) =>
+            document.TryGetValue(key, out var value) && value is not null ? value.ToString() : null;
+
+        return new SerializableShowManifest
+        {
+            PackageIdentifier = Manifest.Id,
+            PackageName = Manifest.Name,
+            PackageVersion = Manifest.Version,
+            Channel = string.IsNullOrWhiteSpace(Manifest.Channel) ? null : Manifest.Channel,
+            SourceName = Package.SourceName,
+            SourceKind = Package.SourceKind,
+            Publisher = Manifest.Publisher,
+            Author = Manifest.Author,
+            Moniker = Manifest.Moniker,
+            Description = Manifest.Description,
+            ShortDescription = GetString("ShortDescription"),
+            PackageUrl = Manifest.PackageUrl,
+            PublisherUrl = Manifest.PublisherUrl,
+            PublisherSupportUrl = Manifest.PublisherSupportUrl,
+            License = Manifest.License,
+            LicenseUrl = Manifest.LicenseUrl,
+            PrivacyUrl = Manifest.PrivacyUrl,
+            Copyright = Manifest.Copyright,
+            CopyrightUrl = Manifest.CopyrightUrl,
+            ReleaseNotes = Manifest.ReleaseNotes,
+            ReleaseNotesUrl = Manifest.ReleaseNotesUrl,
+            Tags = Manifest.Tags,
+            PackageDependencies = Manifest.PackageDependencies,
+            Documentation = Manifest.Documentation,
+            Agreements = Manifest.Agreements,
+            Installers = Manifest.Installers.Select(SerializableInstaller.FromInstaller).ToList(),
+            SelectedInstaller = SelectedInstaller is null ? null : SerializableInstaller.FromInstaller(SelectedInstaller),
+            CachedFiles = CachedFiles,
+            Warnings = Warnings,
+            SourceWarnings = SourceWarnings,
+        };
+    }
 }
+
+public record SerializableShowManifest
+{
+    public required string PackageIdentifier { get; init; }
+    public required string PackageName { get; init; }
+    public required string PackageVersion { get; init; }
+    public string? Channel { get; init; }
+    public required string SourceName { get; init; }
+    public required SourceKind SourceKind { get; init; }
+    public string? Publisher { get; init; }
+    public string? Author { get; init; }
+    public string? Moniker { get; init; }
+    public string? Description { get; init; }
+    public string? ShortDescription { get; init; }
+    public string? PackageUrl { get; init; }
+    public string? PublisherUrl { get; init; }
+    public string? PublisherSupportUrl { get; init; }
+    public string? License { get; init; }
+    public string? LicenseUrl { get; init; }
+    public string? PrivacyUrl { get; init; }
+    public string? Copyright { get; init; }
+    public string? CopyrightUrl { get; init; }
+    public string? ReleaseNotes { get; init; }
+    public string? ReleaseNotesUrl { get; init; }
+    public List<string> Tags { get; init; } = [];
+    public List<string> PackageDependencies { get; init; } = [];
+    public List<Documentation> Documentation { get; init; } = [];
+    public List<PackageAgreement> Agreements { get; init; } = [];
+    public List<SerializableInstaller> Installers { get; init; } = [];
+    public SerializableInstaller? SelectedInstaller { get; init; }
+    public List<string> CachedFiles { get; init; } = [];
+    public List<string> Warnings { get; init; } = [];
+    public List<RepositoryWarning> SourceWarnings { get; init; } = [];
+}
+
+public record SerializableInstaller
+{
+    public string? Architecture { get; init; }
+    public string? InstallerType { get; init; }
+    public string? NestedInstallerType { get; init; }
+    public string? InstallerUrl { get; init; }
+    public string? InstallerSha256 { get; init; }
+    public string? ProductCode { get; init; }
+    public string? InstallerLocale { get; init; }
+    public string? Scope { get; init; }
+    public string? ReleaseDate { get; init; }
+    public string? PackageFamilyName { get; init; }
+    public string? UpgradeCode { get; init; }
+    public List<string> Platforms { get; init; } = [];
+    public string? MinimumOsVersion { get; init; }
+    public InstallerSwitches Switches { get; init; } = new();
+    public List<string> Commands { get; init; } = [];
+    public List<string> PackageDependencies { get; init; } = [];
+
+    public static SerializableInstaller FromInstaller(Installer installer) => new()
+    {
+        Architecture = installer.Architecture,
+        InstallerType = installer.InstallerType,
+        NestedInstallerType = installer.NestedInstallerType,
+        InstallerUrl = installer.Url,
+        InstallerSha256 = installer.Sha256,
+        ProductCode = installer.ProductCode,
+        InstallerLocale = installer.Locale,
+        Scope = installer.Scope,
+        ReleaseDate = installer.ReleaseDate,
+        PackageFamilyName = installer.PackageFamilyName,
+        UpgradeCode = installer.UpgradeCode,
+        Platforms = installer.Platforms,
+        MinimumOsVersion = installer.MinimumOsVersion,
+        Switches = installer.Switches,
+        Commands = installer.Commands,
+        PackageDependencies = installer.PackageDependencies,
+    };
+}
+
+[JsonSerializable(typeof(SerializableShowManifest))]
+[JsonSerializable(typeof(List<SerializableShowManifest>))]
+[JsonSerializable(typeof(RepositoryWarning))]
+[JsonSerializable(typeof(List<RepositoryWarning>))]
+[JsonSourceGenerationOptions(WriteIndented = true)]
+public partial class PingetJsonContext : JsonSerializerContext;
 
 public record VersionsResult
 {
     public required SearchMatch Package { get; init; }
     public required List<VersionKey> Versions { get; init; }
     public List<string> Warnings { get; init; } = [];
+    public List<RepositoryWarning> SourceWarnings { get; init; } = [];
 }
 
 public record CacheWarmResult
@@ -291,6 +461,7 @@ public record CacheWarmResult
     public required SearchMatch Package { get; init; }
     public List<string> CachedFiles { get; init; } = [];
     public List<string> Warnings { get; init; } = [];
+    public List<RepositoryWarning> SourceWarnings { get; init; } = [];
 }
 
 public record SourceUpdateResult

--- a/dotnet/src/Devolutions.Pinget.Core/Repository.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Repository.cs
@@ -25,14 +25,21 @@ public class Repository : IDisposable
     private readonly string _appRoot;
     private readonly HttpClient _client;
     private readonly bool _useSystemWingetSources;
+    private readonly Action<RepositoryWarning>? _diagnostics;
     private SourceStore _store;
 
-    private Repository(string appRoot, HttpClient client, SourceStore store, bool useSystemWingetSources)
+    private Repository(
+        string appRoot,
+        HttpClient client,
+        SourceStore store,
+        bool useSystemWingetSources,
+        Action<RepositoryWarning>? diagnostics)
     {
         _appRoot = appRoot;
         _client = client;
         _store = store;
         _useSystemWingetSources = useSystemWingetSources;
+        _diagnostics = diagnostics;
     }
 
     /// <summary>
@@ -48,7 +55,7 @@ public class Repository : IDisposable
         var store = SourceStoreManager.Load(appRoot);
         var client = new HttpClient();
         client.DefaultRequestHeaders.UserAgent.ParseAdd(options.UserAgent);
-        return new Repository(appRoot, client, store, useSystemWingetSources);
+        return new Repository(appRoot, client, store, useSystemWingetSources, options.Diagnostics);
     }
 
     internal static IEnumerable<string> GetSqliteNativeLibraryCandidates(string assemblyDirectory)
@@ -362,18 +369,19 @@ public class Repository : IDisposable
 
     public SearchResponse Search(PackageQuery query)
     {
-        var (matches, warnings, truncated) = SearchLocated(query, SearchSemantics.Many);
+        var (matches, warnings, failures, truncated) = SearchLocated(query, SearchSemantics.Many);
         return new SearchResponse
         {
             Matches = matches.Select(m => m.Display).ToList(),
             Warnings = warnings,
+            SourceWarnings = failures.Select(f => f.Warning).ToList(),
             Truncated = truncated
         };
     }
 
     public List<Dictionary<string, object?>> SearchManifests(PackageQuery query)
     {
-        var (matches, _, _) = SearchLocated(query, SearchSemantics.Many);
+        var (matches, _, _, _) = SearchLocated(query, SearchSemantics.Many);
         return StructuredOutput.CollapseManifestResults(matches.Select(located =>
         {
             var (_, structuredDocument, _) = ManifestForMatch(located, query);
@@ -385,42 +393,91 @@ public class Repository : IDisposable
 
     public ShowResult Show(PackageQuery query)
     {
-        var (located, warnings) = FindSingleMatch(query);
-        var (manifest, structuredDocument, cachedFiles) = ManifestForMatch(located, query);
-        var selectedInstaller = SelectInstaller(manifest.Installers, query);
+        var (located, warnings, sourceWarnings) = FindSingleMatch(query);
+        return CreateShowResult(located, query, warnings, sourceWarnings);
+    }
 
-        return new ShowResult
+    public SerializableShowManifest ShowManifest(PackageQuery query) => Show(query).ToSerializableManifest();
+
+    public ShowResult ShowFirstMatchAcrossSources(PackageQuery query)
+    {
+        if (query.Source is not null)
+            return Show(query);
+
+        var allWarnings = new List<string>();
+        var allFailures = new List<SourceSearchFailure>();
+
+        foreach (var sourceIndex in ResolveSearchSourceIndexes(null))
         {
-            Package = located.Display,
-            Manifest = manifest,
-            SelectedInstaller = selectedInstaller,
-            CachedFiles = cachedFiles,
-            Warnings = warnings,
-            StructuredDocument = structuredDocument,
-        };
+            var sourceQuery = query with { Source = _store.Sources[sourceIndex].Name };
+            var (matches, warnings, failures, _) = SearchLocated(sourceQuery, SearchSemantics.Single);
+            allWarnings.AddRange(warnings);
+            allFailures.AddRange(failures);
+
+            if (matches.Count == 0)
+                continue;
+
+            if (matches.Count > 1)
+                throw new MultiplePackageMatchesException(matches.Select(m => m.Display));
+
+            return CreateShowResult(matches[0], query, allWarnings, allFailures.Select(f => f.Warning).ToList());
+        }
+
+        if (allFailures.Count > 0)
+            throw new SourceSearchException(allFailures[0].Warning, allFailures[0].Exception);
+
+        throw new InvalidOperationException("no package matched the supplied query");
+    }
+
+    private ShowResult CreateShowResult(
+        LocatedMatch located,
+        PackageQuery query,
+        List<string> warnings,
+        List<RepositoryWarning> sourceWarnings)
+    {
+        try
+        {
+            var (manifest, structuredDocument, cachedFiles) = ManifestForMatch(located, query);
+            return new ShowResult
+            {
+                Package = located.Display,
+                Manifest = manifest,
+                SelectedInstaller = SelectInstaller(manifest.Installers, query),
+                CachedFiles = cachedFiles,
+                Warnings = warnings,
+                SourceWarnings = sourceWarnings,
+                StructuredDocument = structuredDocument,
+            };
+        }
+        catch (Exception ex)
+        {
+            var warning = CreateSourceWarning(located.SourceIndex, "manifest", ex);
+            EmitDiagnostic(warning);
+            throw new SourceSearchException(warning, UnwrapSourceOperationException(ex));
+        }
     }
 
     public VersionsResult ShowVersions(PackageQuery query)
     {
-        var (located, warnings) = FindSingleMatch(query);
+        var (located, warnings, sourceWarnings) = FindSingleMatch(query);
         var versions = VersionsForMatch(located, query);
-        return new VersionsResult { Package = located.Display, Versions = versions, Warnings = warnings };
+        return new VersionsResult { Package = located.Display, Versions = versions, Warnings = warnings, SourceWarnings = sourceWarnings };
     }
 
     public VersionsResult SearchVersions(PackageQuery query)
     {
-        var (located, warnings) = FindSingleMatchWithSemantics(query, SearchSemantics.Many);
+        var (located, warnings, sourceWarnings) = FindSingleMatchWithSemantics(query, SearchSemantics.Many);
         var versions = VersionsForMatch(located, query);
-        return new VersionsResult { Package = located.Display, Versions = versions, Warnings = warnings };
+        return new VersionsResult { Package = located.Display, Versions = versions, Warnings = warnings, SourceWarnings = sourceWarnings };
     }
 
     // ── Cache warm ──
 
     public CacheWarmResult WarmCache(PackageQuery query)
     {
-        var (located, warnings) = FindSingleMatch(query);
+        var (located, warnings, sourceWarnings) = FindSingleMatch(query);
         var (_, _, cachedFiles) = ManifestForMatch(located, query);
-        return new CacheWarmResult { Package = located.Display, CachedFiles = cachedFiles, Warnings = warnings };
+        return new CacheWarmResult { Package = located.Display, CachedFiles = cachedFiles, Warnings = warnings, SourceWarnings = sourceWarnings };
     }
 
     // ── List ──
@@ -444,7 +501,7 @@ public class Repository : IDisposable
         if (needsAvailable && hasFilter)
         {
             var availableQuery = PackageQueryFromListQuery(query);
-            var (matches, srcWarnings, _) = SearchLocated(availableQuery, SearchSemantics.Many);
+            var (matches, srcWarnings, _, _) = SearchLocated(availableQuery, SearchSemantics.Many);
             warnings.AddRange(srcWarnings);
             var candidates = matches.Select(m => m.Display).ToList();
             foreach (var pkg in installed)
@@ -694,7 +751,7 @@ public class Repository : IDisposable
         if (!string.IsNullOrWhiteSpace(request.ManifestPath))
             return LoadManifestFromPath(request.ManifestPath!);
 
-        var (located, _) = FindSingleMatch(request.Query);
+        var (located, _, _) = FindSingleMatch(request.Query);
         var (manifest, _, _) = ManifestForMatch(located, request.Query);
         return manifest;
     }
@@ -933,12 +990,15 @@ public class Repository : IDisposable
 
     // ── Internal search machinery ──
 
-    private (List<LocatedMatch> Matches, List<string> Warnings, bool Truncated) SearchLocated(
+    private record SourceSearchFailure(RepositoryWarning Warning, Exception Exception);
+
+    private (List<LocatedMatch> Matches, List<string> Warnings, List<SourceSearchFailure> Failures, bool Truncated) SearchLocated(
         PackageQuery query, SearchSemantics semantics)
     {
         var indexes = ResolveSearchSourceIndexes(query.Source);
         var matches = new List<LocatedMatch>();
         var warnings = new List<string>();
+        var failures = new List<SourceSearchFailure>();
         bool truncated = false;
 
         foreach (var index in indexes)
@@ -949,9 +1009,14 @@ public class Repository : IDisposable
                 truncated |= srcTruncated;
                 matches.AddRange(sourceMatches);
             }
-            catch
+            catch (Exception ex)
             {
-                warnings.Add($"Failed when searching source; results will not be included: {_store.Sources[index].Name}");
+                var operation = ex is SourceOperationException sourceOperation ? sourceOperation.Operation : "search";
+                var exception = UnwrapSourceOperationException(ex);
+                var warning = CreateSourceWarning(index, operation, exception);
+                failures.Add(new SourceSearchFailure(warning, exception));
+                warnings.Add($"Failed when searching source '{warning.SourceName}'; results will not be included: {warning.Message}");
+                EmitDiagnostic(warning);
             }
         }
 
@@ -968,7 +1033,7 @@ public class Repository : IDisposable
             }
         }
 
-        return (matches, warnings, truncated);
+        return (matches, warnings, failures, truncated);
     }
 
     private (List<LocatedMatch> Matches, bool Truncated) SearchSource(
@@ -1036,9 +1101,27 @@ public class Repository : IDisposable
         int sourceIndex, PackageQuery query, SearchSemantics semantics)
     {
         var source = _store.Sources[sourceIndex];
-        var info = RestSource.LoadInformation(_client, source, _appRoot);
+        RestSource.RestInformation info;
+        try
+        {
+            info = RestSource.LoadInformation(_client, source, _appRoot);
+        }
+        catch (Exception ex)
+        {
+            throw new SourceOperationException("information", ex);
+        }
 
-        var (results, truncated) = RestSource.Search(_client, source, query, info, semantics);
+        (List<RestSource.RestMatchResult> Results, bool Truncated) search;
+        try
+        {
+            search = RestSource.Search(_client, source, query, info, semantics);
+        }
+        catch (Exception ex)
+        {
+            throw new SourceOperationException("search", ex);
+        }
+
+        var (results, truncated) = search;
         return (results.Select(r => new LocatedMatch
         {
             Display = new SearchMatch
@@ -1057,6 +1140,56 @@ public class Repository : IDisposable
         }).ToList(), truncated);
     }
 
+    private RepositoryWarning CreateSourceWarning(int sourceIndex, string operation, Exception exception)
+    {
+        var source = _store.Sources[sourceIndex];
+        return new RepositoryWarning
+        {
+            Operation = operation,
+            SourceName = source.Name,
+            SourceKind = source.Kind,
+            SourceArg = source.Arg,
+            SourceIdentifier = source.Identifier,
+            RequestUri = SourceRequestUri(source, operation),
+            CachePath = SourceDiagnosticCachePath(source),
+            Message = exception.Message,
+            ExceptionType = exception.GetType().FullName,
+            HttpStatusCode = exception is HttpRequestException httpException && httpException.StatusCode.HasValue
+                ? (int)httpException.StatusCode.Value
+                : null,
+        };
+    }
+
+    private static string SourceRequestUri(SourceRecord source, string operation) =>
+        source.Kind == SourceKind.Rest
+            ? operation switch
+            {
+                "search" => $"{source.Arg.TrimEnd('/')}/manifestSearch",
+                "manifest" => $"{source.Arg.TrimEnd('/')}/packageManifests",
+                "information" => $"{source.Arg.TrimEnd('/')}/information",
+                _ => source.Arg,
+            }
+            : source.Arg;
+
+    private string? SourceDiagnosticCachePath(SourceRecord source) =>
+        source.Kind switch
+        {
+            SourceKind.PreIndexed => PreIndexedSource.IndexPath(source, _appRoot),
+            SourceKind.Rest => Path.Combine(SourceStoreManager.SourceStateDir(source, _appRoot), "rest_info.json"),
+            _ => null,
+        };
+
+    private void EmitDiagnostic(RepositoryWarning warning) => _diagnostics?.Invoke(warning);
+
+    private sealed class SourceOperationException(string operation, Exception innerException)
+        : Exception(innerException.Message, innerException)
+    {
+        public string Operation { get; } = operation;
+    }
+
+    private static Exception UnwrapSourceOperationException(Exception exception) =>
+        exception is SourceOperationException { InnerException: { } innerException } ? innerException : exception;
+
     private SqliteConnection OpenPreindexedConnection(int sourceIndex)
     {
         var source = _store.Sources[sourceIndex];
@@ -1074,25 +1207,26 @@ public class Repository : IDisposable
         return conn;
     }
 
-    private (LocatedMatch Match, List<string> Warnings) FindSingleMatch(PackageQuery query)
+    private (LocatedMatch Match, List<string> Warnings, List<RepositoryWarning> SourceWarnings) FindSingleMatch(PackageQuery query)
         => FindSingleMatchWithSemantics(query, SearchSemantics.Single);
 
-    private (LocatedMatch Match, List<string> Warnings) FindSingleMatchWithSemantics(
+    private (LocatedMatch Match, List<string> Warnings, List<RepositoryWarning> SourceWarnings) FindSingleMatchWithSemantics(
         PackageQuery query, SearchSemantics semantics)
     {
-        var (matches, warnings, _) = SearchLocated(query, semantics);
+        var (matches, warnings, failures, _) = SearchLocated(query, semantics);
 
         if (matches.Count == 0)
-            throw new InvalidOperationException("no package matched the supplied query");
-
-        if (matches.Count > 1)
         {
-            var choices = string.Join(", ", matches.Take(10)
-                .Select(m => $"{m.Display.Name} [{m.Display.Id}] ({m.Display.SourceName})"));
-            throw new InvalidOperationException($"multiple packages matched: {choices}");
+            if (query.Source is not null && failures.Count > 0)
+                throw new SourceSearchException(failures[0].Warning, failures[0].Exception);
+
+            throw new InvalidOperationException("no package matched the supplied query");
         }
 
-        return (matches[0], warnings);
+        if (matches.Count > 1)
+            throw new MultiplePackageMatchesException(matches.Select(m => m.Display));
+
+        return (matches[0], warnings, failures.Select(f => f.Warning).ToList());
     }
 
     private List<VersionKey> VersionsForMatch(LocatedMatch located, PackageQuery query)
@@ -1636,7 +1770,7 @@ public class Repository : IDisposable
     private List<string> CorrelateAllInstalled(List<InstalledPackage> installed)
     {
         var allQuery = new PackageQuery { Count = 100_000 };
-        var (matches, warnings, _) = SearchLocated(allQuery, SearchSemantics.Many);
+        var (matches, warnings, _, _) = SearchLocated(allQuery, SearchSemantics.Many);
         var candidates = matches.Select(m => m.Display).ToList();
         foreach (var pkg in installed)
             pkg.Correlated = CorrelateInstalledPackage(pkg, candidates, true);

--- a/dotnet/src/Devolutions.Pinget.Core/RestSource.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/RestSource.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace Devolutions.Pinget.Core;
 
@@ -34,7 +35,7 @@ internal static class RestSource
             try
             {
                 var cacheJson = File.ReadAllText(cachePath);
-                var cache = JsonSerializer.Deserialize<RestInfoCache>(cacheJson);
+                var cache = JsonSerializer.Deserialize(cacheJson, RestSourceJsonContext.Default.RestInfoCache);
                 if (cache is not null && cache.ExpiresAt > DateTime.UtcNow)
                     return cache.Value;
             }
@@ -66,7 +67,7 @@ internal static class RestSource
 
         // Cache for 1 hour
         var cacheEntry = new RestInfoCache { ExpiresAt = DateTime.UtcNow.AddHours(1), Value = info };
-        File.WriteAllText(cachePath, JsonSerializer.Serialize(cacheEntry));
+        File.WriteAllText(cachePath, JsonSerializer.Serialize(cacheEntry, RestSourceJsonContext.Default.RestInfoCache));
 
         return info;
     }
@@ -277,6 +278,33 @@ internal static class RestSource
             return v.EnumerateArray().Select(x => x.GetString() ?? "").Where(s => s != "").ToList();
         }
 
+        List<string> GetPackageDependencies(JsonElement el)
+        {
+            var direct = GetStrArray(el, "PackageDependencies");
+            if (direct.Count > 0)
+                return direct;
+
+            if (!el.TryGetProperty("Dependencies", out var dependencies) ||
+                dependencies.ValueKind != JsonValueKind.Object ||
+                !dependencies.TryGetProperty("PackageDependencies", out var packageDependencies) ||
+                packageDependencies.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            var result = new List<string>();
+            foreach (var dependency in packageDependencies.EnumerateArray())
+            {
+                if (dependency.ValueKind == JsonValueKind.String)
+                    result.Add(dependency.GetString() ?? "");
+                else if (dependency.ValueKind == JsonValueKind.Object &&
+                         dependency.TryGetProperty("PackageIdentifier", out var packageIdentifier))
+                    result.Add(packageIdentifier.GetString() ?? "");
+            }
+
+            return result.Where(item => !string.IsNullOrWhiteSpace(item)).ToList();
+        }
+
         InstallerSwitches GetSwitches(JsonElement el)
         {
             if (!el.TryGetProperty("InstallerSwitches", out var switches) && !el.TryGetProperty("Switches", out switches))
@@ -322,7 +350,7 @@ internal static class RestSource
                     UpgradeCode = GetOptStr(inst, "UpgradeCode"),
                     Switches = GetSwitches(inst).MergeWith(defaultSwitches),
                     Commands = GetStrArray(inst, "Commands"),
-                    PackageDependencies = GetStrArray(inst, "PackageDependencies"),
+                    PackageDependencies = GetPackageDependencies(inst),
                 });
             }
         }
@@ -374,6 +402,7 @@ internal static class RestSource
             ReleaseNotesUrl = GetOptStr(defaultLocale, "ReleaseNotesUrl"),
             Tags = GetStrArray(defaultLocale, "Tags"),
             Agreements = agreements,
+            PackageDependencies = GetPackageDependencies(installersSource),
             Documentation = docs,
             Installers = installers,
         };
@@ -514,3 +543,6 @@ internal static class RestSource
         public string? MatchCriteria { get; init; }
     }
 }
+
+[JsonSerializable(typeof(RestSource.RestInfoCache))]
+internal partial class RestSourceJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary
- add structured source diagnostics and typed resolution exceptions for embedded `Repository.Show` consumers
- add a serializable Core show manifest API with reflection-free JSON context and route CLI `show --output json|yaml` through it
- add REST source parity tests, including `tessl.tessl`-style exact ID lookup and an optional live `winget.pro` smoke test
- document `RepositoryOptions.AppRoot = null` system WinGet mode and embedded diagnostics usage

## Validation
- `dotnet format dotnet\Devolutions.Pinget.slnx`
- `dotnet build dotnet\Devolutions.Pinget.slnx -c Release`
- `dotnet test dotnet\src\Devolutions.Pinget.Core.Tests\Devolutions.Pinget.Core.Tests.csproj -c Release --no-build`
- built `rust\target\x86_64-pc-windows-msvc\release\pinget_com.dll`
- `pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet\tests\RunTests.ps1')`