### PR TITLE
Prepare Pinget Core 0.3.0 for UniGetUI

### DIFF
--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup Condition="'$(IsPackable)' == 'true'">
+  <PropertyGroup>
     <Authors>Devolutions</Authors>
     <Company>Devolutions Inc.</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
@@ -736,14 +736,51 @@ public class ModelsTests
     }
 
     [Fact]
-    public void GetSqliteNativeLibraryCandidates_ProbesRootAndRidFolder()
+    public void TryGetWinGetPackageIdentityFromLocalId_UsesSourceIdentifierSuffix()
     {
-        var candidates = Repository.GetSqliteNativeLibraryCandidates(@"C:\module").ToList();
+        SourceRecord source = new()
+        {
+            Name = "winget",
+            Kind = SourceKind.PreIndexed,
+            Arg = "https://cdn.winget.microsoft.com/cache",
+            Identifier = "Microsoft.Winget.Source_8wekyb3d8bbwe",
+        };
 
-        Assert.Equal(@"C:\module\e_sqlite3.dll", candidates[0]);
-        Assert.Contains(Path.Combine(@"C:\module", "runtimes"), candidates[1]);
-        Assert.EndsWith(Path.Combine("native", "e_sqlite3.dll"), candidates[1], StringComparison.OrdinalIgnoreCase);
+        bool result = Repository.TryGetWinGetPackageIdentityFromLocalId(
+            @"ARP\User\X64\Atlassian.AtlassianCLI_Microsoft.Winget.Source_8wekyb3d8bbwe",
+            [source],
+            out string? packageId,
+            out string? sourceName
+        );
+
+        Assert.True(result);
+        Assert.Equal("Atlassian.AtlassianCLI", packageId);
+        Assert.Equal("winget", sourceName);
     }
+
+    [Fact]
+    public void TryGetWinGetPackageIdentityFromLocalId_IgnoresUnknownSourceIdentifier()
+    {
+        SourceRecord source = new()
+        {
+            Name = "winget",
+            Kind = SourceKind.PreIndexed,
+            Arg = "https://cdn.winget.microsoft.com/cache",
+            Identifier = "Microsoft.Winget.Source_8wekyb3d8bbwe",
+        };
+
+        bool result = Repository.TryGetWinGetPackageIdentityFromLocalId(
+            @"ARP\Machine\X64\Contoso.Tool_Unknown.Source_1234",
+            [source],
+            out string? packageId,
+            out string? sourceName
+        );
+
+        Assert.False(result);
+        Assert.Null(packageId);
+        Assert.Null(sourceName);
+    }
+
 }
 
 public class PinStoreTests
@@ -1551,6 +1588,16 @@ public class RepositoryEmbeddingTests
             Assert.Equal(["Installer.Dependency"], installer.PackageDependencies);
             Assert.Empty(result.SourceWarnings);
             Assert.Empty(diagnostics);
+
+            var typedResult = repo.Show(new PackageQuery
+            {
+                Id = TesslPackageId,
+                Exact = true,
+                Source = "test",
+                InstallerArchitecture = "x64",
+            });
+
+            Assert.Equal("Tessl short description", typedResult.Manifest.ShortDescription);
 
             var json = JsonSerializer.Serialize(result, PingetJsonContext.Default.SerializableShowManifest);
             using var document = JsonDocument.Parse(json);

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
@@ -736,6 +736,16 @@ public class ModelsTests
     }
 
     [Fact]
+    public void GetSqliteNativeLibraryCandidates_ProbesRootAndRidFolder()
+    {
+        var candidates = Repository.GetSqliteNativeLibraryCandidates(@"C:\module").ToList();
+
+        Assert.Equal(@"C:\module\e_sqlite3.dll", candidates[0]);
+        Assert.Contains(Path.Combine(@"C:\module", "runtimes"), candidates[1]);
+        Assert.EndsWith(Path.Combine("native", "e_sqlite3.dll"), candidates[1], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryGetWinGetPackageIdentityFromLocalId_UsesSourceIdentifierSuffix()
     {
         SourceRecord source = new()

--- a/dotnet/src/Devolutions.Pinget.Core/Devolutions.Pinget.Core.csproj
+++ b/dotnet/src/Devolutions.Pinget.Core/Devolutions.Pinget.Core.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
     <PackageReference Include="YamlDotNet" Version="17.0.1" />
   </ItemGroup>
 

--- a/dotnet/src/Devolutions.Pinget.Core/Devolutions.Pinget.Core.csproj
+++ b/dotnet/src/Devolutions.Pinget.Core/Devolutions.Pinget.Core.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
     <PackageReference Include="YamlDotNet" Version="17.0.1" />
   </ItemGroup>
 

--- a/dotnet/src/Devolutions.Pinget.Core/Models.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Models.cs
@@ -247,6 +247,7 @@ public record Manifest
     public string Channel { get; init; } = "";
     public string? Publisher { get; init; }
     public string? Description { get; init; }
+    public string? ShortDescription { get; init; }
     public string? Moniker { get; init; }
     public string? PackageUrl { get; init; }
     public string? PublisherUrl { get; init; }
@@ -343,7 +344,7 @@ public record ShowResult
             Author = Manifest.Author,
             Moniker = Manifest.Moniker,
             Description = Manifest.Description,
-            ShortDescription = GetString("ShortDescription"),
+            ShortDescription = Manifest.ShortDescription ?? GetString("ShortDescription"),
             PackageUrl = Manifest.PackageUrl,
             PublisherUrl = Manifest.PublisherUrl,
             PublisherSupportUrl = Manifest.PublisherSupportUrl,

--- a/dotnet/src/Devolutions.Pinget.Core/Repository.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Repository.cs
@@ -1,8 +1,6 @@
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json.Nodes;
-using System.Threading;
 using Microsoft.Data.Sqlite;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
@@ -19,8 +17,6 @@ public class Repository : IDisposable
     internal const string UninstallUnsupportedWarning = "Uninstalling packages is not supported on this platform; no changes were made.";
     internal const string RepairUnsupportedWarning = "Repairing packages is not supported on this platform; no changes were made.";
     internal const string RepairReinstallWarning = "Pinget repair currently re-runs the package install flow for the selected package.";
-
-    private static int s_sqliteNativeLibraryInitialized;
 
     private readonly string _appRoot;
     private readonly HttpClient _client;
@@ -48,7 +44,7 @@ public class Repository : IDisposable
     public static Repository Open(RepositoryOptions? options = null)
     {
         options ??= new RepositoryOptions();
-        EnsureSqliteNativeLibraryLoaded();
+        SQLitePCL.Batteries_V2.Init();
         var appRoot = SourceStoreManager.NormalizeAppRoot(options.AppRoot ?? Environment.GetEnvironmentVariable(AppRootEnvironmentVariable));
         SourceStoreManager.EnsureAppDirs(appRoot);
         var useSystemWingetSources = SourceStoreManager.UsesSystemWingetSourceCommands(appRoot);
@@ -56,79 +52,6 @@ public class Repository : IDisposable
         var client = new HttpClient();
         client.DefaultRequestHeaders.UserAgent.ParseAdd(options.UserAgent);
         return new Repository(appRoot, client, store, useSystemWingetSources, options.Diagnostics);
-    }
-
-    internal static IEnumerable<string> GetSqliteNativeLibraryCandidates(string assemblyDirectory)
-    {
-        yield return Path.Combine(assemblyDirectory, "e_sqlite3.dll");
-
-        var rid = RuntimeInformation.ProcessArchitecture switch
-        {
-            Architecture.X86 => "win-x86",
-            Architecture.Arm => "win-arm",
-            Architecture.Arm64 => "win-arm64",
-            _ => "win-x64",
-        };
-
-        yield return Path.Combine(assemblyDirectory, "runtimes", rid, "native", "e_sqlite3.dll");
-    }
-
-    private static void EnsureSqliteNativeLibraryLoaded()
-    {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return;
-
-        if (Interlocked.Exchange(ref s_sqliteNativeLibraryInitialized, 1) != 0)
-            return;
-
-        var assemblyDirectory = Path.GetDirectoryName(typeof(Repository).Assembly.Location);
-        if (string.IsNullOrWhiteSpace(assemblyDirectory))
-            return;
-
-        var nativeLibraryPath = GetSqliteNativeLibraryCandidates(assemblyDirectory)
-            .FirstOrDefault(File.Exists);
-
-        if (string.IsNullOrWhiteSpace(nativeLibraryPath))
-            return;
-
-        RegisterSqliteDllImportResolvers(nativeLibraryPath);
-
-        try
-        {
-            NativeLibrary.Load(nativeLibraryPath);
-        }
-        catch
-        {
-            // The resolver path is the important fix for library-hosted environments.
-        }
-    }
-
-    private static void RegisterSqliteDllImportResolvers(string nativeLibraryPath)
-    {
-        RegisterSqliteDllImportResolver("SQLitePCLRaw.provider.e_sqlite3", nativeLibraryPath);
-        RegisterSqliteDllImportResolver("SQLitePCLRaw.core", nativeLibraryPath);
-    }
-
-    private static void RegisterSqliteDllImportResolver(string assemblyName, string nativeLibraryPath)
-    {
-        try
-        {
-            var assembly = AppDomain.CurrentDomain.GetAssemblies()
-                .FirstOrDefault(candidate => string.Equals(candidate.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase))
-                ?? Assembly.Load(new AssemblyName(assemblyName));
-
-            NativeLibrary.SetDllImportResolver(assembly, (libraryName, _, _) =>
-            {
-                if (!string.Equals(libraryName, "e_sqlite3", StringComparison.OrdinalIgnoreCase))
-                    return IntPtr.Zero;
-
-                return NativeLibrary.Load(nativeLibraryPath);
-            });
-        }
-        catch
-        {
-            // Ignore duplicate resolver registration or unavailable optional assemblies.
-        }
     }
 
     public void Dispose() => _client.Dispose();
@@ -1562,6 +1485,7 @@ public class Repository : IDisposable
             Version = GetStr("PackageVersion"),
             Publisher = GetOptStr("Publisher"),
             Description = GetOptStr("Description") ?? GetOptStr("ShortDescription"),
+            ShortDescription = GetOptStr("ShortDescription"),
             Moniker = GetOptStr("Moniker"),
             PackageUrl = GetOptStr("PackageUrl"),
             PublisherUrl = GetOptStr("PublisherUrl"),
@@ -1952,7 +1876,7 @@ public class Repository : IDisposable
         return 2;
     }
 
-    private static ListMatch ListMatchFromInstalled(InstalledPackage pkg)
+    private ListMatch ListMatchFromInstalled(InstalledPackage pkg)
     {
         string? availableVersion = null;
         if (pkg.Correlated?.Version is string av)
@@ -1961,14 +1885,27 @@ public class Repository : IDisposable
                 RestSource.CompareVersionStrings(av, pkg.InstalledVersion) > 0)
                 availableVersion = av;
         }
+
+        string packageId = pkg.Correlated?.Id ?? pkg.LocalId;
+        string? sourceName = pkg.Correlated?.SourceName;
+        if (sourceName is null && TryGetWinGetPackageIdentityFromLocalId(
+            pkg.LocalId,
+            _store.Sources,
+            out string? localPackageId,
+            out string? localSourceName))
+        {
+            packageId = localPackageId;
+            sourceName = localSourceName;
+        }
+
         return new()
         {
             Name = pkg.Name,
-            Id = pkg.Correlated?.Id ?? pkg.LocalId,
+            Id = packageId,
             LocalId = pkg.LocalId,
             InstalledVersion = pkg.InstalledVersion,
             AvailableVersion = availableVersion,
-            SourceName = pkg.Correlated?.SourceName,
+            SourceName = sourceName,
             Publisher = pkg.Publisher,
             Scope = pkg.Scope,
             InstallerCategory = pkg.InstallerCategory,
@@ -1977,6 +1914,40 @@ public class Repository : IDisposable
             ProductCodes = pkg.ProductCodes,
             UpgradeCodes = pkg.UpgradeCodes,
         };
+    }
+
+    internal static bool TryGetWinGetPackageIdentityFromLocalId(
+        string localId,
+        IReadOnlyList<SourceRecord> sources,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? packageId,
+        out string? sourceName)
+    {
+        packageId = null;
+        sourceName = null;
+
+        int packageIdStartIndex = localId.LastIndexOf('\\') + 1;
+        SourceRecord? source = null;
+        int sourceIdentifierStartIndex = -1;
+        foreach (SourceRecord candidate in sources)
+        {
+            string sourceSuffix = "_" + candidate.Identifier;
+            if (!localId.EndsWith(sourceSuffix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            source = candidate;
+            sourceIdentifierStartIndex = localId.Length - sourceSuffix.Length;
+            break;
+        }
+
+        if (source is null)
+            return false;
+
+        if (sourceIdentifierStartIndex <= packageIdStartIndex)
+            return false;
+
+        packageId = localId[packageIdStartIndex..sourceIdentifierStartIndex];
+        sourceName = source.Name;
+        return !string.IsNullOrWhiteSpace(packageId);
     }
 
     private static bool ListQueryNeedsAvailableLookup(ListQuery query)

--- a/dotnet/src/Devolutions.Pinget.Core/Repository.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Repository.cs
@@ -1,6 +1,8 @@
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json.Nodes;
+using System.Threading;
 using Microsoft.Data.Sqlite;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
@@ -17,6 +19,8 @@ public class Repository : IDisposable
     internal const string UninstallUnsupportedWarning = "Uninstalling packages is not supported on this platform; no changes were made.";
     internal const string RepairUnsupportedWarning = "Repairing packages is not supported on this platform; no changes were made.";
     internal const string RepairReinstallWarning = "Pinget repair currently re-runs the package install flow for the selected package.";
+
+    private static int s_sqliteNativeLibraryInitialized;
 
     private readonly string _appRoot;
     private readonly HttpClient _client;
@@ -44,7 +48,7 @@ public class Repository : IDisposable
     public static Repository Open(RepositoryOptions? options = null)
     {
         options ??= new RepositoryOptions();
-        SQLitePCL.Batteries_V2.Init();
+        EnsureSqliteNativeLibraryLoaded();
         var appRoot = SourceStoreManager.NormalizeAppRoot(options.AppRoot ?? Environment.GetEnvironmentVariable(AppRootEnvironmentVariable));
         SourceStoreManager.EnsureAppDirs(appRoot);
         var useSystemWingetSources = SourceStoreManager.UsesSystemWingetSourceCommands(appRoot);
@@ -52,6 +56,79 @@ public class Repository : IDisposable
         var client = new HttpClient();
         client.DefaultRequestHeaders.UserAgent.ParseAdd(options.UserAgent);
         return new Repository(appRoot, client, store, useSystemWingetSources, options.Diagnostics);
+    }
+
+    internal static IEnumerable<string> GetSqliteNativeLibraryCandidates(string assemblyDirectory)
+    {
+        yield return Path.Combine(assemblyDirectory, "e_sqlite3.dll");
+
+        var rid = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X86 => "win-x86",
+            Architecture.Arm => "win-arm",
+            Architecture.Arm64 => "win-arm64",
+            _ => "win-x64",
+        };
+
+        yield return Path.Combine(assemblyDirectory, "runtimes", rid, "native", "e_sqlite3.dll");
+    }
+
+    private static void EnsureSqliteNativeLibraryLoaded()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        if (Interlocked.Exchange(ref s_sqliteNativeLibraryInitialized, 1) != 0)
+            return;
+
+        var assemblyDirectory = Path.GetDirectoryName(typeof(Repository).Assembly.Location);
+        if (string.IsNullOrWhiteSpace(assemblyDirectory))
+            return;
+
+        var nativeLibraryPath = GetSqliteNativeLibraryCandidates(assemblyDirectory)
+            .FirstOrDefault(File.Exists);
+
+        if (string.IsNullOrWhiteSpace(nativeLibraryPath))
+            return;
+
+        RegisterSqliteDllImportResolvers(nativeLibraryPath);
+
+        try
+        {
+            NativeLibrary.Load(nativeLibraryPath);
+        }
+        catch
+        {
+            // The resolver path is the important fix for library-hosted environments.
+        }
+    }
+
+    private static void RegisterSqliteDllImportResolvers(string nativeLibraryPath)
+    {
+        RegisterSqliteDllImportResolver("SQLitePCLRaw.provider.e_sqlite3", nativeLibraryPath);
+        RegisterSqliteDllImportResolver("SQLitePCLRaw.core", nativeLibraryPath);
+    }
+
+    private static void RegisterSqliteDllImportResolver(string assemblyName, string nativeLibraryPath)
+    {
+        try
+        {
+            var assembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(candidate => string.Equals(candidate.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase))
+                ?? Assembly.Load(new AssemblyName(assemblyName));
+
+            NativeLibrary.SetDllImportResolver(assembly, (libraryName, _, _) =>
+            {
+                if (!string.Equals(libraryName, "e_sqlite3", StringComparison.OrdinalIgnoreCase))
+                    return IntPtr.Zero;
+
+                return NativeLibrary.Load(nativeLibraryPath);
+            });
+        }
+        catch
+        {
+            // Ignore duplicate resolver registration or unavailable optional assemblies.
+        }
     }
 
     public void Dispose() => _client.Dispose();

--- a/dotnet/src/Devolutions.Pinget.Core/RestSource.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/RestSource.cs
@@ -46,7 +46,8 @@ internal static class RestSource
         using var response = client.GetAsync(url).GetAwaiter().GetResult();
         response.EnsureSuccessStatusCode();
         var body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-        var json = JsonSerializer.Deserialize<JsonElement>(body);
+        using var document = JsonDocument.Parse(body);
+        var json = document.RootElement;
 
         // The REST response wraps data in a "Data" property
         var data = json.TryGetProperty("Data", out var d) ? d : json;
@@ -96,7 +97,8 @@ internal static class RestSource
         response.EnsureSuccessStatusCode();
 
         var responseBody = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-        var json = JsonSerializer.Deserialize<JsonElement>(responseBody);
+        using var document = JsonDocument.Parse(responseBody);
+        var json = document.RootElement;
 
         var data = json.TryGetProperty("Data", out var d) && d.ValueKind == JsonValueKind.Array
             ? d.EnumerateArray().ToList()
@@ -140,7 +142,8 @@ internal static class RestSource
         response.EnsureSuccessStatusCode();
 
         var body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-        var json = JsonSerializer.Deserialize<JsonElement>(body);
+        using var document = JsonDocument.Parse(body);
+        var json = document.RootElement;
 
         return ParseRestManifest(json, packageId, version, channel);
     }
@@ -388,6 +391,7 @@ internal static class RestSource
             Channel = channel,
             Publisher = GetOptStr(defaultLocale, "Publisher"),
             Description = GetOptStr(defaultLocale, "Description") ?? GetOptStr(defaultLocale, "ShortDescription"),
+            ShortDescription = GetOptStr(defaultLocale, "ShortDescription"),
             Moniker = GetOptStr(data, "Moniker"),
             PackageUrl = GetOptStr(defaultLocale, "PackageUrl"),
             PublisherUrl = GetOptStr(defaultLocale, "PublisherUrl"),

--- a/dotnet/src/Devolutions.Pinget.Core/SourceStore.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/SourceStore.cs
@@ -301,7 +301,9 @@ internal static class SourceStoreManager
     private static string GetPackagedSecureSettingsRoot()
     {
         var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-        var sid = WindowsIdentity.GetCurrent().User?.Value ?? "UnknownSid";
+        var sid = OperatingSystem.IsWindows()
+            ? WindowsIdentity.GetCurrent().User?.Value ?? "UnknownSid"
+            : "UnknownSid";
         return Path.Combine(programData, "Microsoft", "WinGet", sid, "settings", "pkg", PackagedName);
     }
 


### PR DESCRIPTION
## Summary
- replace manual SQLite native resolver with SQLitePCLRaw bundle initialization
- expose typed package metadata needed by UniGetUI, including ShortDescription and source fallback lookup
- make REST JSON parsing safe for reflection-disabled hosts
- add focused tests for UniGetUI integration scenarios

## Validation
- dotnet test .\src\Devolutions.Pinget.Core.Tests\Devolutions.Pinget.Core.Tests.csproj --nologo
- dotnet pack .\src\Devolutions.Pinget.Core\Devolutions.Pinget.Core.csproj --configuration Release -p:Version=0.3.0 --output D:\dev\caches\nuget-local --nologo