### PR TITLE
chore(release-plz): change default git_tag_name

### DIFF
--- a/rust/release-plz.toml
+++ b/rust/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 dependencies_update = true
 git_release_enable = false
+git_tag_name = "{{ package }}-v{{ version }}"
 semver_check = true
 pr_branch_prefix = "release-plz/"
 pr_name = "chore(release): prepare for publishing"


### PR DESCRIPTION
By default, it's:

- "{{ package }}-v{{ version }}" for workspaces containing more than one public package.
- "v{{ version }}" for projects containing a single crate or workspaces containing just one public package.

But we want the package name in the tag even if we only publish a single crate.