### PR TITLE
Implement portable installer support for WinGet packages

### DIFF
--- a/dotnet/src/Devolutions.Pinget.Cli/CliJsonContext.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/CliJsonContext.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace Devolutions.Pinget.Cli;
+
+internal sealed record SourceExportEntry(
+    string Name,
+    string Type,
+    string Arg,
+    string Data,
+    string Identifier,
+    string TrustLevel,
+    bool Explicit,
+    int Priority);
+
+internal sealed record SourceExportPayload(List<SourceExportEntry> Sources);
+
+internal sealed record PackageExportEntry(
+    string PackageIdentifier,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Version);
+
+internal sealed record PackageExportSourceDetails(string Name, string Argument, string Type);
+
+internal sealed record PackageExportSource(
+    PackageExportSourceDetails SourceDetails,
+    List<PackageExportEntry> Packages);
+
+internal sealed record PackagesExportPayload(string Schema, List<PackageExportSource> Sources);
+
+[JsonSerializable(typeof(SourceExportPayload))]
+[JsonSerializable(typeof(PackagesExportPayload))]
+[JsonSourceGenerationOptions(WriteIndented = true)]
+internal partial class CliJsonContext : JsonSerializerContext;

--- a/dotnet/src/Devolutions.Pinget.Cli/Devolutions.Pinget.Cli.csproj
+++ b/dotnet/src/Devolutions.Pinget.Cli/Devolutions.Pinget.Cli.csproj
@@ -31,6 +31,10 @@
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Devolutions.Pinget.Core.Tests" />
+  </ItemGroup>
+
   <Target Name="UseStaticWindowsRuntimeForNativeAot"
           AfterTargets="SetupOSSpecificProps"
           Condition="'$(PublishAot)' == 'true'

--- a/dotnet/src/Devolutions.Pinget.Cli/Program.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/Program.cs
@@ -6,7 +6,7 @@ using Devolutions.Pinget.Cli;
 using Devolutions.Pinget.Core;
 using YamlDotNet.Serialization;
 
-const string Version = "0.6.0";
+const string Version = "0.7.0";
 const string UpgradeUnsupportedWarning = "Upgrading packages is not supported on this platform; no changes were made.";
 
 if (args.Length == 1 && (string.Equals(args[0], "--version", StringComparison.OrdinalIgnoreCase) || string.Equals(args[0], "-v", StringComparison.OrdinalIgnoreCase)))

--- a/dotnet/src/Devolutions.Pinget.Cli/Program.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/Program.cs
@@ -315,6 +315,7 @@ upgradeCommand.SetHandler((ctx) =>
         var upgradeable = result.Matches.Where(m => m.AvailableVersion is not null).ToList();
         var pins = repo.ListPins();
         var upgradedCount = 0;
+        var failureCount = 0;
         if (upgradeable.Count == 0)
         {
             Console.WriteLine("No applicable upgrade found.");
@@ -330,6 +331,7 @@ upgradeCommand.SetHandler((ctx) =>
                     if (pin?.PinType == PinType.Blocking)
                     {
                         Console.WriteLine($"  Package is blocked by pin {pin.Version}; remove the pin before upgrading.");
+                        failureCount++;
                         continue;
                     }
 
@@ -358,13 +360,23 @@ upgradeCommand.SetHandler((ctx) =>
                             : $"  Failed to upgrade {m.Id} (exit code: {r.ExitCode})");
                     if (r.Success && !r.NoOp)
                         upgradedCount++;
+                    else if (!r.Success)
+                        failureCount++;
                 }
                 catch (Exception ex)
                 {
                     Console.Error.WriteLine($"  Error upgrading {m.Id}: {ex.Message}");
+                    failureCount++;
                 }
             }
-            Console.WriteLine($"{upgradedCount} package(s) upgraded.");
+            Console.WriteLine($"{upgradedCount} of {upgradeable.Count} package(s) upgraded.");
+            if (failureCount > 0)
+            {
+                // Surface the failure to the caller (UniGetUI, scripts, etc.) so
+                // they don't treat a partial failure as success.
+                Console.Error.WriteLine($"{failureCount} package(s) failed to upgrade during upgrade --all");
+                ctx.ExitCode = 1;
+            }
         }
     }
 });

--- a/dotnet/src/Devolutions.Pinget.Cli/Program.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/Program.cs
@@ -5,7 +5,6 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
 using Devolutions.Pinget.Cli;
 using Devolutions.Pinget.Core;
-using YamlDotNet.Serialization;
 
 const string Version = "0.7.0";
 const string UpgradeUnsupportedWarning = "Upgrading packages is not supported on this platform; no changes were made.";
@@ -1275,7 +1274,7 @@ void WriteStructuredOutput<T>(T value, OutputFormat output, JsonTypeInfo<T> type
             Console.WriteLine(StructuredOutputSerializer.SerializeJson(value, typeInfo));
             break;
         case OutputFormat.Yaml:
-            Console.Write(StructuredOutputSerializer.SerializeYaml(value!));
+            Console.Write(StructuredOutputSerializer.SerializeYaml(value, typeInfo));
             break;
         default:
             throw new InvalidOperationException("Text output should be handled separately.");
@@ -1792,8 +1791,7 @@ void WriteJsonNode(JsonNode value, OutputFormat output)
     switch (output)
     {
         case OutputFormat.Yaml:
-            var structured = StructuredOutputSerializer.JsonNodeToDynamic(value) ?? new object();
-            Console.Write(new SerializerBuilder().Build().Serialize(structured));
+            Console.Write(StructuredOutputSerializer.SerializeYaml(value));
             break;
         default:
             Console.WriteLine(value.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));

--- a/dotnet/src/Devolutions.Pinget.Cli/Program.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/Program.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 using Devolutions.Pinget.Cli;
 using Devolutions.Pinget.Core;
 using YamlDotNet.Serialization;
@@ -77,18 +78,18 @@ searchCommand.SetHandler((ctx) =>
         if (ctx.ParseResult.GetValueForOption(sVersionsOpt))
             throw new InvalidOperationException("--manifests cannot be combined with --versions");
 
-        WriteStructuredOutput(repo.SearchManifests(query), output);
+        WriteDynamicStructuredOutput(repo.SearchManifests(query), output);
     }
     else if (ctx.ParseResult.GetValueForOption(sVersionsOpt))
     {
         var result = repo.SearchVersions(query);
-        if (output != OutputFormat.Text) WriteStructuredOutput(result, output);
+        if (output != OutputFormat.Text) WriteStructuredOutput(result, output, PingetJsonContext.Default.VersionsResult);
         else PrintVersions(result);
     }
     else
     {
         var result = repo.Search(query);
-        if (output != OutputFormat.Text) WriteStructuredOutput(result, output);
+        if (output != OutputFormat.Text) WriteStructuredOutput(result, output, PingetJsonContext.Default.SearchResponse);
         else PrintSearch(result);
     }
 });
@@ -129,7 +130,7 @@ showCommand.SetHandler((ctx) =>
     if (ctx.ParseResult.GetValueForOption(shVerOpt))
     {
         var result = repo.ShowVersions(query);
-        if (output != OutputFormat.Text) WriteStructuredOutput(result, output);
+        if (output != OutputFormat.Text) WriteStructuredOutput(result, output, PingetJsonContext.Default.VersionsResult);
         else PrintVersions(result);
     }
     else
@@ -181,7 +182,7 @@ listCommand.SetHandler((ctx) =>
 
     using var repo = Repository.Open();
     var result = repo.List(query);
-    if (output != OutputFormat.Text) WriteStructuredOutput(result, output);
+    if (output != OutputFormat.Text) WriteStructuredOutput(result, output, PingetJsonContext.Default.ListResponse);
     else PrintListResult(result, details, upgrade);
 });
 
@@ -302,7 +303,7 @@ upgradeCommand.SetHandler((ctx) =>
 
     if (!doInstall)
     {
-        if (output != OutputFormat.Text) WriteStructuredOutput(result, output);
+        if (output != OutputFormat.Text) WriteStructuredOutput(result, output, PingetJsonContext.Default.ListResponse);
         else PrintListResult(result, false, true);
     }
     else if (!string.IsNullOrWhiteSpace(manifestPath))
@@ -437,18 +438,16 @@ sourceUpdateCmd.SetHandler((source) =>
 sourceExportCmd.SetHandler(() =>
 {
     using var repo = Repository.Open();
-    var sources = repo.ListSources().Select(s => new
-    {
-        Name = s.Name,
-        Type = FormatSourceType(s.Kind),
-        Arg = s.Arg,
-        Data = s.Identifier,
-        Identifier = s.Identifier,
-        TrustLevel = s.TrustLevel,
-        Explicit = s.Explicit,
-        Priority = s.Priority,
-    });
-    Console.WriteLine(StructuredOutputSerializer.SerializeJson(new { Sources = sources }));
+    var sources = repo.ListSources().Select(s => new SourceExportEntry(
+        Name: s.Name,
+        Type: FormatSourceType(s.Kind),
+        Arg: s.Arg,
+        Data: s.Identifier,
+        Identifier: s.Identifier,
+        TrustLevel: s.TrustLevel,
+        Explicit: s.Explicit,
+        Priority: s.Priority)).ToList();
+    Console.WriteLine(StructuredOutputSerializer.SerializeJson(new SourceExportPayload(sources), CliJsonContext.Default.SourceExportPayload));
 });
 
 sourceAddCmd.SetHandler((ctx) =>
@@ -523,7 +522,7 @@ cacheWarmCmd.SetHandler((ctx) =>
     };
     using var repo = Repository.Open();
     var result = repo.WarmCache(query);
-    if (output != OutputFormat.Text) WriteStructuredOutput(result, output);
+    if (output != OutputFormat.Text) WriteStructuredOutput(result, output, PingetJsonContext.Default.CacheWarmResult);
     else
     {
         Console.WriteLine($"Warmed cache for {result.Package.Name} [{result.Package.Id}]");
@@ -572,26 +571,22 @@ exportCommand.SetHandler((output, source, includeVersions) =>
 {
     using var repo = Repository.Open();
     var listResult = repo.List(new ListQuery { Source = source is not null ? source : null, Query = source is not null ? " " : null });
-    var packages = listResult.Matches.Select(m =>
-    {
-        var pkg = new Dictionary<string, object> { ["PackageIdentifier"] = m.Id };
-        if (includeVersions && m.InstalledVersion is not null) pkg["Version"] = m.InstalledVersion;
-        return pkg;
-    }).ToList();
+    var packages = listResult.Matches.Select(m => new PackageExportEntry(
+        PackageIdentifier: m.Id,
+        Version: includeVersions ? m.InstalledVersion : null)).ToList();
 
-    var export = new
-    {
-        Schema = "https://aka.ms/winget-packages.schema.2.0.json",
-        Sources = new[]
-        {
-            new
-            {
-                SourceDetails = new { Name = source ?? "winget", Argument = "https://cdn.winget.microsoft.com/cache", Type = "Microsoft.PreIndexed" },
-                Packages = packages
-            }
-        }
-    };
-    File.WriteAllText(output, StructuredOutputSerializer.SerializeJson(export));
+    var export = new PackagesExportPayload(
+        Schema: "https://aka.ms/winget-packages.schema.2.0.json",
+        Sources:
+        [
+            new PackageExportSource(
+                SourceDetails: new PackageExportSourceDetails(
+                    Name: source ?? "winget",
+                    Argument: "https://cdn.winget.microsoft.com/cache",
+                    Type: "Microsoft.PreIndexed"),
+                Packages: packages)
+        ]);
+    File.WriteAllText(output, StructuredOutputSerializer.SerializeJson(export, CliJsonContext.Default.PackagesExportPayload));
     Console.WriteLine($"Exported {packages.Count} packages to {output}");
 }, exOutputOpt, exSourceOpt, exVersionsOpt);
 
@@ -1140,8 +1135,8 @@ importCommand.SetHandler((ctx) =>
 
     if (!File.Exists(file)) { Console.Error.WriteLine($"error: File not found: {file}"); return; }
     var jsonText = File.ReadAllText(file);
-    var doc = JsonSerializer.Deserialize<JsonElement>(jsonText);
-    var sources = doc.GetProperty("Sources").EnumerateArray().ToList();
+    using var doc = JsonDocument.Parse(jsonText);
+    var sources = doc.RootElement.GetProperty("Sources").EnumerateArray().ToList();
 
     using var repo = Repository.Open();
     int total = 0;
@@ -1272,12 +1267,27 @@ static OutputFormat GetOutputFormat(string? value) =>
         _ => OutputFormat.Text,
     };
 
-void WriteStructuredOutput(object value, OutputFormat output)
+void WriteStructuredOutput<T>(T value, OutputFormat output, JsonTypeInfo<T> typeInfo)
 {
     switch (output)
     {
         case OutputFormat.Json:
-            Console.WriteLine(StructuredOutputSerializer.SerializeJson(value));
+            Console.WriteLine(StructuredOutputSerializer.SerializeJson(value, typeInfo));
+            break;
+        case OutputFormat.Yaml:
+            Console.Write(StructuredOutputSerializer.SerializeYaml(value!));
+            break;
+        default:
+            throw new InvalidOperationException("Text output should be handled separately.");
+    }
+}
+
+void WriteDynamicStructuredOutput(object value, OutputFormat output)
+{
+    switch (output)
+    {
+        case OutputFormat.Json:
+            Console.WriteLine(StructuredOutputSerializer.SerializeJson(StructuredOutputSerializer.DynamicToJsonNode(value)));
             break;
         case OutputFormat.Yaml:
             Console.Write(StructuredOutputSerializer.SerializeYaml(value));
@@ -1287,20 +1297,9 @@ void WriteStructuredOutput(object value, OutputFormat output)
     }
 }
 
-void WriteManifestStructuredOutput(object value, OutputFormat output)
+void WriteManifestStructuredOutput(SerializableShowManifest value, OutputFormat output)
 {
-    if (output == OutputFormat.Yaml && value is List<Dictionary<string, object?>> documents)
-    {
-        var serializer = new SerializerBuilder().Build();
-        foreach (var document in documents)
-        {
-            Console.Write("---\n");
-            Console.Write(serializer.Serialize(document));
-        }
-        return;
-    }
-
-    WriteStructuredOutput(value, output);
+    WriteStructuredOutput(value, output, PingetJsonContext.Default.SerializableShowManifest);
 }
 
 static void PrintSearch(SearchResponse result)
@@ -1793,7 +1792,7 @@ void WriteJsonNode(JsonNode value, OutputFormat output)
     switch (output)
     {
         case OutputFormat.Yaml:
-            var structured = JsonSerializer.Deserialize<object>(value.ToJsonString()) ?? new object();
+            var structured = StructuredOutputSerializer.JsonNodeToDynamic(value) ?? new object();
             Console.Write(new SerializerBuilder().Build().Serialize(structured));
             break;
         default:

--- a/dotnet/src/Devolutions.Pinget.Cli/StructuredOutputSerializer.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/StructuredOutputSerializer.cs
@@ -1,4 +1,7 @@
+using System.Collections;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
 using Devolutions.Pinget.Core;
 using YamlDotNet.Serialization;
 
@@ -8,11 +11,120 @@ public static class StructuredOutputSerializer
 {
     public static JsonSerializerOptions JsonOptions { get; } = new() { WriteIndented = true };
 
-    public static string SerializeJson(object value) =>
-        value is SerializableShowManifest showManifest
-            ? JsonSerializer.Serialize(showManifest, PingetJsonContext.Default.SerializableShowManifest)
-            : JsonSerializer.Serialize(value, JsonOptions);
+    public static string SerializeJson<T>(T value, JsonTypeInfo<T> typeInfo) =>
+        JsonSerializer.Serialize(value, typeInfo);
+
+    public static string SerializeJson(JsonNode? node) =>
+        node?.ToJsonString(JsonOptions) ?? "null";
 
     public static string SerializeYaml(object value) =>
         new SerializerBuilder().Build().Serialize(value);
+
+    internal static JsonNode? DynamicToJsonNode(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                return null;
+            case JsonNode node:
+                return node.DeepClone();
+            case string s:
+                return JsonValue.Create(s);
+            case bool b:
+                return JsonValue.Create(b);
+            case int i:
+                return JsonValue.Create(i);
+            case long l:
+                return JsonValue.Create(l);
+            case double d:
+                return JsonValue.Create(d);
+            case decimal m:
+                return JsonValue.Create(m);
+            case DateTime dt:
+                return JsonValue.Create(dt);
+            case DateTimeOffset dto:
+                return JsonValue.Create(dto);
+            case Guid g:
+                return JsonValue.Create(g);
+            case IDictionary<string, object?> dict:
+                {
+                    var obj = new JsonObject();
+                    foreach (var (key, val) in dict)
+                        obj[key] = DynamicToJsonNode(val);
+                    return obj;
+                }
+            case IEnumerable enumerable:
+                {
+                    var array = new JsonArray();
+                    foreach (var item in enumerable)
+                        array.Add(DynamicToJsonNode(item));
+                    return array;
+                }
+            default:
+                return JsonValue.Create(value.ToString());
+        }
+    }
+
+    internal static object? JsonNodeToDynamic(JsonNode? node)
+    {
+        switch (node)
+        {
+            case null:
+                return null;
+            case JsonObject obj:
+                {
+                    var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
+                    foreach (var (key, child) in obj)
+                        dict[key] = JsonNodeToDynamic(child);
+                    return dict;
+                }
+            case JsonArray array:
+                {
+                    var list = new List<object?>(array.Count);
+                    foreach (var child in array)
+                        list.Add(JsonNodeToDynamic(child));
+                    return list;
+                }
+            case JsonValue jsonValue:
+                return ConvertJsonValue(jsonValue);
+            default:
+                return node.ToJsonString();
+        }
+    }
+
+    private static object? ConvertJsonValue(JsonValue jsonValue)
+    {
+        // JsonValue can be backed either by a parsed JsonElement
+        // (JsonNode.Parse) or by a strongly-typed primitive built via
+        // JsonValue.Create<T>. The JsonElement form supports cross-type
+        // GetValue calls; the primitive form requires an exact T match.
+        switch (jsonValue.GetValueKind())
+        {
+            case JsonValueKind.String:
+                return jsonValue.GetValue<string>();
+            case JsonValueKind.True:
+                return true;
+            case JsonValueKind.False:
+                return false;
+            case JsonValueKind.Null:
+                return null;
+            case JsonValueKind.Number:
+                if (jsonValue.TryGetValue<long>(out var lv)) return lv;
+                if (jsonValue.TryGetValue<int>(out var iv)) return (long)iv;
+                if (jsonValue.TryGetValue<short>(out var sv)) return (long)sv;
+                if (jsonValue.TryGetValue<byte>(out var bv)) return (long)bv;
+                if (jsonValue.TryGetValue<uint>(out var uiv)) return (long)uiv;
+                if (jsonValue.TryGetValue<double>(out var dv)) return dv;
+                if (jsonValue.TryGetValue<float>(out var fv)) return (double)fv;
+                if (jsonValue.TryGetValue<decimal>(out var mv)) return (double)mv;
+                if (jsonValue.TryGetValue<JsonElement>(out var elem))
+                {
+                    if (elem.TryGetInt64(out var el)) return el;
+                    return elem.GetDouble();
+                }
+                return jsonValue.ToJsonString();
+            default:
+                return jsonValue.ToJsonString();
+        }
+    }
 }

--- a/dotnet/src/Devolutions.Pinget.Cli/StructuredOutputSerializer.cs
+++ b/dotnet/src/Devolutions.Pinget.Cli/StructuredOutputSerializer.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization.Metadata;
 using Devolutions.Pinget.Core;
-using YamlDotNet.Serialization;
 
 namespace Devolutions.Pinget.Cli;
 
@@ -17,8 +16,11 @@ public static class StructuredOutputSerializer
     public static string SerializeJson(JsonNode? node) =>
         node?.ToJsonString(JsonOptions) ?? "null";
 
-    public static string SerializeYaml(object value) =>
-        new SerializerBuilder().Build().Serialize(value);
+    public static string SerializeYaml(object? value) =>
+        YamlEmitter.EmitDocument(value);
+
+    public static string SerializeYaml<T>(T value, JsonTypeInfo<T> typeInfo) =>
+        YamlEmitter.EmitDocument(JsonSerializer.SerializeToNode(value, typeInfo));
 
     internal static JsonNode? DynamicToJsonNode(object? value)
     {
@@ -65,66 +67,4 @@ public static class StructuredOutputSerializer
         }
     }
 
-    internal static object? JsonNodeToDynamic(JsonNode? node)
-    {
-        switch (node)
-        {
-            case null:
-                return null;
-            case JsonObject obj:
-                {
-                    var dict = new Dictionary<string, object?>(StringComparer.Ordinal);
-                    foreach (var (key, child) in obj)
-                        dict[key] = JsonNodeToDynamic(child);
-                    return dict;
-                }
-            case JsonArray array:
-                {
-                    var list = new List<object?>(array.Count);
-                    foreach (var child in array)
-                        list.Add(JsonNodeToDynamic(child));
-                    return list;
-                }
-            case JsonValue jsonValue:
-                return ConvertJsonValue(jsonValue);
-            default:
-                return node.ToJsonString();
-        }
-    }
-
-    private static object? ConvertJsonValue(JsonValue jsonValue)
-    {
-        // JsonValue can be backed either by a parsed JsonElement
-        // (JsonNode.Parse) or by a strongly-typed primitive built via
-        // JsonValue.Create<T>. The JsonElement form supports cross-type
-        // GetValue calls; the primitive form requires an exact T match.
-        switch (jsonValue.GetValueKind())
-        {
-            case JsonValueKind.String:
-                return jsonValue.GetValue<string>();
-            case JsonValueKind.True:
-                return true;
-            case JsonValueKind.False:
-                return false;
-            case JsonValueKind.Null:
-                return null;
-            case JsonValueKind.Number:
-                if (jsonValue.TryGetValue<long>(out var lv)) return lv;
-                if (jsonValue.TryGetValue<int>(out var iv)) return (long)iv;
-                if (jsonValue.TryGetValue<short>(out var sv)) return (long)sv;
-                if (jsonValue.TryGetValue<byte>(out var bv)) return (long)bv;
-                if (jsonValue.TryGetValue<uint>(out var uiv)) return (long)uiv;
-                if (jsonValue.TryGetValue<double>(out var dv)) return dv;
-                if (jsonValue.TryGetValue<float>(out var fv)) return (double)fv;
-                if (jsonValue.TryGetValue<decimal>(out var mv)) return (double)mv;
-                if (jsonValue.TryGetValue<JsonElement>(out var elem))
-                {
-                    if (elem.TryGetInt64(out var el)) return el;
-                    return elem.GetDouble();
-                }
-                return jsonValue.ToJsonString();
-            default:
-                return jsonValue.ToJsonString();
-        }
-    }
 }

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CliExportPayloadTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CliExportPayloadTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Devolutions.Pinget.Cli;
+using Xunit;
+
+namespace Devolutions.Pinget.Core.Tests;
+
+public class CliExportPayloadTests
+{
+    [Fact]
+    public void PackagesExportPayload_OmitsVersionWhenNull()
+    {
+        // Regression: the legacy code conditionally inserted the "Version" key
+        // into a Dictionary<string,object>. The new typed record relies on
+        // [JsonIgnore(WhenWritingNull)] to reproduce that wire-format shape;
+        // make sure the field is genuinely absent (not serialized as null).
+        var payload = new PackagesExportPayload(
+            Schema: "https://aka.ms/winget-packages.schema.2.0.json",
+            Sources:
+            [
+                new PackageExportSource(
+                    SourceDetails: new PackageExportSourceDetails(
+                        Name: "winget",
+                        Argument: "https://cdn.winget.microsoft.com/cache",
+                        Type: "Microsoft.PreIndexed"),
+                    Packages:
+                    [
+                        new PackageExportEntry(PackageIdentifier: "Microsoft.PowerToys", Version: null)
+                    ])
+            ]);
+
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(payload, CliJsonContext.Default.PackagesExportPayload));
+        var package = document.RootElement.GetProperty("Sources")[0].GetProperty("Packages")[0];
+
+        Assert.Equal("Microsoft.PowerToys", package.GetProperty("PackageIdentifier").GetString());
+        Assert.False(package.TryGetProperty("Version", out _));
+    }
+
+    [Fact]
+    public void PackagesExportPayload_IncludesVersionWhenPresent()
+    {
+        var payload = new PackagesExportPayload(
+            Schema: "https://aka.ms/winget-packages.schema.2.0.json",
+            Sources:
+            [
+                new PackageExportSource(
+                    SourceDetails: new PackageExportSourceDetails(
+                        Name: "winget",
+                        Argument: "https://cdn.winget.microsoft.com/cache",
+                        Type: "Microsoft.PreIndexed"),
+                    Packages:
+                    [
+                        new PackageExportEntry(PackageIdentifier: "Microsoft.PowerToys", Version: "0.99.0")
+                    ])
+            ]);
+
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(payload, CliJsonContext.Default.PackagesExportPayload));
+        var package = document.RootElement.GetProperty("Sources")[0].GetProperty("Packages")[0];
+
+        Assert.Equal("0.99.0", package.GetProperty("Version").GetString());
+    }
+
+    [Fact]
+    public void PackagesExportPayload_MatchesWingetSchemaShape()
+    {
+        // The export command produces files consumed by `winget import`. Lock
+        // down the top-level shape so a future refactor doesn't accidentally
+        // rename fields (e.g. SourceDetails → sourceDetails, or Argument → Arg).
+        var payload = new PackagesExportPayload(
+            Schema: "https://aka.ms/winget-packages.schema.2.0.json",
+            Sources:
+            [
+                new PackageExportSource(
+                    SourceDetails: new PackageExportSourceDetails(
+                        Name: "winget",
+                        Argument: "https://cdn.winget.microsoft.com/cache",
+                        Type: "Microsoft.PreIndexed"),
+                    Packages: [])
+            ]);
+
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(payload, CliJsonContext.Default.PackagesExportPayload));
+        var root = document.RootElement;
+
+        Assert.Equal("https://aka.ms/winget-packages.schema.2.0.json", root.GetProperty("Schema").GetString());
+        var source = root.GetProperty("Sources")[0];
+        var details = source.GetProperty("SourceDetails");
+        Assert.Equal("winget", details.GetProperty("Name").GetString());
+        Assert.Equal("https://cdn.winget.microsoft.com/cache", details.GetProperty("Argument").GetString());
+        Assert.Equal("Microsoft.PreIndexed", details.GetProperty("Type").GetString());
+        Assert.False(details.TryGetProperty("Arg", out _));
+        Assert.True(source.GetProperty("Packages").ValueKind == JsonValueKind.Array);
+    }
+
+    [Fact]
+    public void SourceExportPayload_OmitsInternalAnonymousArtifacts()
+    {
+        // Anonymous-type serialization in trim/AOT mode can leak compiler-
+        // generated names. Confirm the explicit record produces nothing of
+        // the kind.
+        var payload = new SourceExportPayload(
+        [
+            new SourceExportEntry(
+                Name: "winget",
+                Type: "Microsoft.PreIndexed.Package",
+                Arg: "https://cdn.winget.microsoft.com/cache",
+                Data: "Microsoft.Winget.Source_8wekyb3d8bbwe",
+                Identifier: "Microsoft.Winget.Source_8wekyb3d8bbwe",
+                TrustLevel: "Trusted",
+                Explicit: false,
+                Priority: 0)
+        ]);
+
+        var json = StructuredOutputSerializer.SerializeJson(payload, CliJsonContext.Default.SourceExportPayload);
+
+        Assert.DoesNotContain("<>", json);
+        Assert.DoesNotContain("AnonymousType", json);
+        Assert.DoesNotContain("k__BackingField", json);
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CliJsonCompatibilityTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CliJsonCompatibilityTests.cs
@@ -29,7 +29,7 @@ public class CliJsonCompatibilityTests
             Truncated = false,
         };
 
-        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(response));
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(response, PingetJsonContext.Default.ListResponse));
         var match = document.RootElement.GetProperty("Matches")[0];
 
         Assert.Equal("Microsoft.PowerToys", match.GetProperty("Id").GetString());
@@ -64,7 +64,7 @@ public class CliJsonCompatibilityTests
             Truncated = false,
         };
 
-        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(response));
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(response, PingetJsonContext.Default.SearchResponse));
         var match = document.RootElement.GetProperty("Matches")[0];
 
         Assert.Equal("winget", match.GetProperty("SourceName").GetString());
@@ -103,7 +103,7 @@ public class CliJsonCompatibilityTests
             ],
         };
 
-        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(manifest));
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(manifest, PingetJsonContext.Default.SerializableShowManifest));
         var root = document.RootElement;
 
         Assert.Equal("Microsoft.PowerToys", root.GetProperty(nameof(SerializableShowManifest.PackageIdentifier)).GetString());
@@ -133,25 +133,20 @@ public class CliJsonCompatibilityTests
     [Fact]
     public void StructuredJsonSerializer_PreservesSourceExportPascalCaseShape()
     {
-        var export = new
-        {
-            Sources = new[]
-            {
-                new
-                {
-                    Name = "winget",
-                    Type = "Microsoft.PreIndexed.Package",
-                    Arg = "https://cdn.winget.microsoft.com/cache",
-                    Data = "Microsoft.Winget.Source_8wekyb3d8bbwe",
-                    Identifier = "Microsoft.Winget.Source_8wekyb3d8bbwe",
-                    TrustLevel = "Trusted",
-                    Explicit = false,
-                    Priority = 0,
-                }
-            }
-        };
+        var export = new SourceExportPayload(
+        [
+            new SourceExportEntry(
+                Name: "winget",
+                Type: "Microsoft.PreIndexed.Package",
+                Arg: "https://cdn.winget.microsoft.com/cache",
+                Data: "Microsoft.Winget.Source_8wekyb3d8bbwe",
+                Identifier: "Microsoft.Winget.Source_8wekyb3d8bbwe",
+                TrustLevel: "Trusted",
+                Explicit: false,
+                Priority: 0)
+        ]);
 
-        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(export));
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(export, CliJsonContext.Default.SourceExportPayload));
         var source = document.RootElement.GetProperty("Sources")[0];
 
         Assert.Equal("winget", source.GetProperty("Name").GetString());
@@ -185,7 +180,7 @@ public class CliJsonCompatibilityTests
             ],
         };
 
-        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(result));
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(result, PingetJsonContext.Default.VersionsResult));
         var versions = document.RootElement.GetProperty("Versions");
 
         Assert.Equal("0.99.0", versions[0].GetProperty("Version").GetString());
@@ -220,7 +215,7 @@ public class CliJsonCompatibilityTests
             Truncated = false,
         };
 
-        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(response));
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(response, PingetJsonContext.Default.ListResponse));
         var match = document.RootElement.GetProperty("Matches")[0];
 
         Assert.Equal(JsonValueKind.Null, match.GetProperty("AvailableVersion").ValueKind);
@@ -251,7 +246,7 @@ public class CliJsonCompatibilityTests
             Truncated = false,
         };
 
-        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(response));
+        using var document = JsonDocument.Parse(StructuredOutputSerializer.SerializeJson(response, PingetJsonContext.Default.SearchResponse));
         var match = document.RootElement.GetProperty("Matches")[0];
 
         Assert.Equal("Microsoft To Do", match.GetProperty("Name").GetString());

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
@@ -2155,72 +2155,26 @@ Installers:
     }
 
     [Fact]
-    public void BuildWingetPortableInstallArguments_PreservesWingetCoherenceFlags()
+    public void IsPortableZipInstaller_DetectsNestedPortableZip()
     {
-        var manifest = new Manifest
-        {
-            Id = "JesseDuffield.lazygit",
-            Name = "lazygit",
-            Version = "0.61.1",
-        };
-
-        var request = new InstallRequest
-        {
-            Query = new PackageQuery
-            {
-                Id = "JesseDuffield.lazygit",
-                Source = "winget",
-                InstallScope = "user",
-            },
-            Mode = InstallerMode.Silent,
-            AcceptPackageAgreements = true,
-        };
-
-        Assert.Equal(
-            new[]
-            {
-                "install",
-                "--id",
-                "JesseDuffield.lazygit",
-                "--exact",
-                "--accept-source-agreements",
-                "--disable-interactivity",
-                "--source",
-                "winget",
-                "--scope",
-                "user",
-                "--accept-package-agreements",
-                "--silent",
-            },
-            InstallerDispatch.BuildWingetPortableInstallArguments(request, manifest));
-    }
-
-    [Fact]
-    public void ShouldDelegatePortableZipInstall_ForNestedPortableZip()
-    {
-        var manifest = new Manifest
-        {
-            Id = "JesseDuffield.lazygit",
-            Name = "lazygit",
-            Version = "0.61.1",
-        };
-
-        var request = new InstallRequest
-        {
-            Query = new PackageQuery
-            {
-                Id = "JesseDuffield.lazygit",
-                Source = "winget",
-            },
-        };
-
         var installer = new Installer
         {
             InstallerType = "zip",
             NestedInstallerType = "portable",
         };
 
-        Assert.True(InstallerDispatch.ShouldDelegatePortableZipInstall(request, manifest, installer));
+        Assert.True(InstallerDispatch.IsPortableZipInstaller(installer));
+    }
+
+    [Fact]
+    public void IsPortableZipInstaller_RejectsPlainZipWithoutNestedPortable()
+    {
+        var installer = new Installer
+        {
+            InstallerType = "zip",
+        };
+
+        Assert.False(InstallerDispatch.IsPortableZipInstaller(installer));
     }
 
     [Fact]

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
@@ -2178,6 +2178,184 @@ Installers:
     }
 
     [Fact]
+    public void PathStartsWith_RejectsStringPrefixCollisions()
+    {
+        // Regression: a naive string.StartsWith would falsely consider
+        // C:\Foobar a child of C:\Foo and let the Links\ sweep delete unrelated
+        // symlinks.
+        Assert.False(InstallerDispatch.PathStartsWithCaseInsensitive(
+            @"C:\Foobar\bin.exe", @"C:\Foo"));
+        Assert.False(InstallerDispatch.PathStartsWithCaseInsensitive(
+            @"C:\Foo\bin.exe.bak", @"C:\Foo\bin.exe"));
+    }
+
+    [Fact]
+    public void PathStartsWith_AcceptsRealChildrenAndSelf()
+    {
+        // Dir install: target lives inside the install dir.
+        Assert.True(InstallerDispatch.PathStartsWithCaseInsensitive(
+            @"C:\Foo\sub\bin.exe", @"C:\Foo"));
+        // File install: target is the same file we removed.
+        Assert.True(InstallerDispatch.PathStartsWithCaseInsensitive(
+            @"C:\Foo\bin.exe", @"C:\Foo\bin.exe"));
+    }
+
+    [Fact]
+    public void PathStartsWith_IsCaseInsensitive()
+    {
+        Assert.True(InstallerDispatch.PathStartsWithCaseInsensitive(
+            @"c:\users\test\appdata\local\microsoft\winget\packages\foo\bin.exe",
+            @"C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Foo"));
+    }
+
+    [Fact]
+    public void PathStartsWith_HandlesMixedSeparators()
+    {
+        // NestedInstallerFiles RelativeFilePath uses '/' in manifests, so the
+        // path we joined can end up mixed-separator on Windows.
+        Assert.True(InstallerDispatch.PathStartsWithCaseInsensitive(
+            @"C:\Foo\sub/bin.exe", @"C:\Foo"));
+    }
+
+    [Fact]
+    public void PortableSourceIdentifier_MapsWingetCatalogToCanonicalId()
+    {
+        Assert.Equal(
+            "Microsoft.Winget.Source_8wekyb3d8bbwe",
+            InstallerDispatch.PortableSourceIdentifier(new PackageQuery { Source = "winget" }));
+        Assert.Equal(
+            "Microsoft.Winget.Source_8wekyb3d8bbwe",
+            InstallerDispatch.PortableSourceIdentifier(new PackageQuery { Source = "WINGET" }));
+    }
+
+    [Fact]
+    public void PortableSourceIdentifier_PassesThroughCustomSources()
+    {
+        Assert.Equal(
+            "internal-feed",
+            InstallerDispatch.PortableSourceIdentifier(new PackageQuery { Source = "internal-feed" }));
+    }
+
+    [Fact]
+    public void PortableSourceIdentifier_DefaultsForMissingOrEmptySource()
+    {
+        Assert.Equal(
+            "Microsoft.Winget.Source_8wekyb3d8bbwe",
+            InstallerDispatch.PortableSourceIdentifier(new PackageQuery()));
+        Assert.Equal(
+            "Microsoft.Winget.Source_8wekyb3d8bbwe",
+            InstallerDispatch.PortableSourceIdentifier(new PackageQuery { Source = "" }));
+    }
+
+    [Fact]
+    public void PortableSubkeyName_MatchesWingetFormat()
+    {
+        Assert.Equal(
+            "BurntSushi.ripgrep.MSVC_Microsoft.Winget.Source_8wekyb3d8bbwe",
+            InstallerDispatch.PortableSubkeyName("BurntSushi.ripgrep.MSVC", "Microsoft.Winget.Source_8wekyb3d8bbwe"));
+    }
+
+    [Fact]
+    public void DeterminePortableAlias_PrefersNestedInstallerAlias()
+    {
+        var installer = new Installer
+        {
+            NestedInstallerFiles = new List<NestedInstallerFile>
+            {
+                new() { RelativeFilePath = "ripgrep/rg.exe", PortableCommandAlias = "rg" }
+            },
+            Commands = new List<string> { "other-name" }
+        };
+        Assert.Equal("rg", InstallerDispatch.DeterminePortableAlias(installer));
+    }
+
+    [Fact]
+    public void DeterminePortableAlias_FallsBackToCommands()
+    {
+        var installer = new Installer
+        {
+            Commands = new List<string> { "nuget" }
+        };
+        Assert.Equal("nuget", InstallerDispatch.DeterminePortableAlias(installer));
+
+        // Nested files exist but none declare PortableCommandAlias.
+        installer = new Installer
+        {
+            NestedInstallerFiles = new List<NestedInstallerFile>
+            {
+                new() { RelativeFilePath = "subdir/bin.exe" }
+            },
+            Commands = new List<string> { "bin" }
+        };
+        Assert.Equal("bin", InstallerDispatch.DeterminePortableAlias(installer));
+    }
+
+    [Fact]
+    public void DeterminePortableAlias_ReturnsNullWithoutAliasOrCommands()
+    {
+        Assert.Null(InstallerDispatch.DeterminePortableAlias(new Installer()));
+    }
+
+    [Fact]
+    public void ResolvePortableInstallLocation_PrefersRequestOverride()
+    {
+        var result = InstallerDispatch.ResolvePortableInstallLocationPure(
+            @"D:\Tools\rg", @"C:\Software\rg-test", "Sub_Source", @"C:\default");
+        Assert.Equal(@"D:\Tools\rg", result);
+    }
+
+    [Fact]
+    public void ResolvePortableInstallLocation_PreservesExistingLocationForUpgrades()
+    {
+        // #4823 scenario: upgrade with no --location must resolve to the
+        // install_location the prior install recorded, not the default root.
+        var result = InstallerDispatch.ResolvePortableInstallLocationPure(
+            null, @"C:\Software\rg-test", "Sub_Source", @"C:\default");
+        Assert.Equal(@"C:\Software\rg-test", result);
+    }
+
+    [Fact]
+    public void ResolvePortableInstallLocation_FallsBackToDefaultRoot()
+    {
+        var result = InstallerDispatch.ResolvePortableInstallLocationPure(
+            null, null, "Sub_Source", @"C:\default");
+        Assert.Equal(Path.Combine(@"C:\default", "Sub_Source"), result);
+    }
+
+    [Fact]
+    public void ResolvePortableInstallLocation_TreatsEmptyStringsAsUnset()
+    {
+        var result = InstallerDispatch.ResolvePortableInstallLocationPure(
+            "", "", "Sub_Source", @"C:\default");
+        Assert.Equal(Path.Combine(@"C:\default", "Sub_Source"), result);
+    }
+
+    [Fact]
+    public void CleanDirectoryContents_RemovesFilesAndSubdirsButKeepsRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"pinget-clean-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "a.txt"), "hello");
+        Directory.CreateDirectory(Path.Combine(root, "nested"));
+        File.WriteAllText(Path.Combine(root, "nested", "b.txt"), "world");
+
+        InstallerDispatch.CleanDirectoryContents(root);
+
+        Assert.True(Directory.Exists(root), "root dir itself must survive");
+        Assert.Empty(Directory.EnumerateFileSystemEntries(root));
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public void CleanDirectoryContents_IsNoOpOnNonexistentDir()
+    {
+        var bogus = Path.Combine(Path.GetTempPath(), $"pinget-clean-test-bogus-{Guid.NewGuid():N}");
+        Assert.False(Directory.Exists(bogus));
+        InstallerDispatch.CleanDirectoryContents(bogus);
+        Assert.False(Directory.Exists(bogus));
+    }
+
+    [Fact]
     public void CreateRepairListQuery_IncludesInstalledSelectors()
     {
         var request = new RepairRequest

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/JsonArrayAddOverloadTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/JsonArrayAddOverloadTests.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Devolutions.Pinget.Core.Tests;
+
+public class JsonArrayAddOverloadTests
+{
+    [Fact]
+    public void JsonArrayAdd_JsonNodeCast_ProducesIdenticalOutput_ToGenericAdd()
+    {
+        // RestSource.BuildSearchBody / AppendRequiredFilters previously called
+        // filters.Add(new JsonObject {...}) which bound to JsonArray.Add<T>(T)
+        // — a method annotated [RequiresDynamicCode]. We now cast the argument
+        // to JsonNode? so overload resolution picks JsonArray.Add(JsonNode?).
+        // Confirm the two paths emit byte-identical JSON.
+        var withGenericAdd = new JsonArray();
+        withGenericAdd.Add(new JsonObject
+        {
+            ["PackageMatchField"] = "PackageIdentifier",
+            ["RequestMatch"] = new JsonObject
+            {
+                ["KeyWord"] = "Microsoft.PowerToys",
+                ["MatchType"] = "Exact",
+            },
+        });
+
+        var withCastedAdd = new JsonArray();
+        withCastedAdd.Add((JsonNode?)new JsonObject
+        {
+            ["PackageMatchField"] = "PackageIdentifier",
+            ["RequestMatch"] = new JsonObject
+            {
+                ["KeyWord"] = "Microsoft.PowerToys",
+                ["MatchType"] = "Exact",
+            },
+        });
+
+        Assert.Equal(withGenericAdd.ToJsonString(), withCastedAdd.ToJsonString());
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/StructuredOutputSerializerTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/StructuredOutputSerializerTests.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Devolutions.Pinget.Cli;
 using Xunit;
-using YamlDotNet.Serialization;
 
 namespace Devolutions.Pinget.Core.Tests;
 
@@ -120,85 +119,5 @@ public class StructuredOutputSerializerTests
 
         source["Name"] = "changed";
         Assert.Equal("winget", (string?)cloned["Name"]);
-    }
-
-    [Fact]
-    public void JsonNodeToDynamic_Null_ReturnsNull()
-    {
-        Assert.Null(StructuredOutputSerializer.JsonNodeToDynamic(null));
-    }
-
-    [Fact]
-    public void JsonNodeToDynamic_JsonObject_ProducesStringDictionary()
-    {
-        var node = new JsonObject
-        {
-            ["Name"] = "winget",
-            ["Priority"] = 7,
-            ["Explicit"] = false,
-            ["LastUpdate"] = (JsonNode?)null,
-        };
-
-        var result = StructuredOutputSerializer.JsonNodeToDynamic(node);
-
-        var dict = Assert.IsType<Dictionary<string, object?>>(result);
-        Assert.Equal("winget", dict["Name"]);
-        Assert.Equal(7L, dict["Priority"]);
-        Assert.Equal(false, dict["Explicit"]);
-        Assert.Null(dict["LastUpdate"]);
-    }
-
-    [Fact]
-    public void JsonNodeToDynamic_JsonArray_ProducesObjectList()
-    {
-        var node = new JsonArray("a", 1, true);
-
-        var result = StructuredOutputSerializer.JsonNodeToDynamic(node);
-
-        var list = Assert.IsType<List<object?>>(result);
-        Assert.Equal(new object?[] { "a", 1L, true }, list);
-    }
-
-    [Fact]
-    public void JsonNodeToDynamic_Number_PrefersInt64WhenIntegral()
-    {
-        var node = JsonNode.Parse("42")!;
-        Assert.Equal(42L, StructuredOutputSerializer.JsonNodeToDynamic(node));
-    }
-
-    [Fact]
-    public void JsonNodeToDynamic_Number_FallsBackToDoubleWhenFractional()
-    {
-        var node = JsonNode.Parse("3.14")!;
-        Assert.Equal(3.14, (double)StructuredOutputSerializer.JsonNodeToDynamic(node)!, precision: 10);
-    }
-
-    [Fact]
-    public void JsonNodeToDynamic_OutputIsAcceptedByYamlDotNet()
-    {
-        // Regression: the settings YAML branch (WriteJsonNode in Program.cs)
-        // feeds the dynamic tree directly into YamlDotNet's serializer. Make
-        // sure the shape we produce is one YamlDotNet can render without
-        // throwing or emitting opaque CLR type names.
-        var input = new JsonObject
-        {
-            ["telemetry"] = new JsonObject { ["disable"] = true },
-            ["network"] = new JsonObject
-            {
-                ["downloader"] = "wininet",
-                ["doProgressTimeoutInSeconds"] = 60,
-            },
-            ["tags"] = new JsonArray("a", "b"),
-        };
-
-        var dynamic = StructuredOutputSerializer.JsonNodeToDynamic(input);
-        var yaml = new SerializerBuilder().Build().Serialize(dynamic!);
-
-        Assert.Contains("telemetry:", yaml);
-        Assert.Contains("disable: true", yaml);
-        Assert.Contains("doProgressTimeoutInSeconds: 60", yaml);
-        Assert.Contains("- a", yaml);
-        Assert.DoesNotContain("JsonElement", yaml);
-        Assert.DoesNotContain("System.", yaml);
     }
 }

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/StructuredOutputSerializerTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/StructuredOutputSerializerTests.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Devolutions.Pinget.Cli;
+using Xunit;
+using YamlDotNet.Serialization;
+
+namespace Devolutions.Pinget.Core.Tests;
+
+public class StructuredOutputSerializerTests
+{
+    [Fact]
+    public void SerializeJson_NullNode_ReturnsNullLiteral()
+    {
+        Assert.Equal("null", StructuredOutputSerializer.SerializeJson((JsonNode?)null));
+    }
+
+    [Fact]
+    public void SerializeJson_Node_UsesIndentedFormatting()
+    {
+        var node = new JsonObject
+        {
+            ["Name"] = "winget",
+            ["Priority"] = 0,
+        };
+
+        var json = StructuredOutputSerializer.SerializeJson(node);
+
+        Assert.Contains("\"Name\"", json);
+        Assert.Contains('\n', json);
+    }
+
+    [Fact]
+    public void DynamicToJsonNode_Null_ReturnsNull()
+    {
+        Assert.Null(StructuredOutputSerializer.DynamicToJsonNode(null));
+    }
+
+    [Theory]
+    [InlineData("hello", JsonValueKind.String)]
+    [InlineData(true, JsonValueKind.True)]
+    [InlineData(false, JsonValueKind.False)]
+    [InlineData(42, JsonValueKind.Number)]
+    [InlineData(9999999999L, JsonValueKind.Number)]
+    [InlineData(3.14, JsonValueKind.Number)]
+    public void DynamicToJsonNode_Primitives_ProduceMatchingJsonValueKind(object value, JsonValueKind expectedKind)
+    {
+        var node = StructuredOutputSerializer.DynamicToJsonNode(value);
+        Assert.NotNull(node);
+        Assert.Equal(expectedKind, node.GetValueKind());
+    }
+
+    [Fact]
+    public void DynamicToJsonNode_Dictionary_ProducesJsonObject()
+    {
+        var dict = new Dictionary<string, object?>
+        {
+            ["Name"] = "PowerToys",
+            ["Version"] = "0.99.0",
+            ["Count"] = 3,
+        };
+
+        var node = StructuredOutputSerializer.DynamicToJsonNode(dict);
+
+        var obj = Assert.IsType<JsonObject>(node);
+        Assert.Equal("PowerToys", (string?)obj["Name"]);
+        Assert.Equal("0.99.0", (string?)obj["Version"]);
+        Assert.Equal(3, (int?)obj["Count"]);
+    }
+
+    [Fact]
+    public void DynamicToJsonNode_List_ProducesJsonArray()
+    {
+        var list = new List<object?> { "one", 2, null, true };
+
+        var node = StructuredOutputSerializer.DynamicToJsonNode(list);
+
+        var array = Assert.IsType<JsonArray>(node);
+        Assert.Equal(4, array.Count);
+        Assert.Equal("one", (string?)array[0]);
+        Assert.Equal(2, (int?)array[1]);
+        Assert.Null(array[2]);
+        Assert.True((bool?)array[3]);
+    }
+
+    [Fact]
+    public void DynamicToJsonNode_NestedStructure_ProducesMatchingJsonTree()
+    {
+        var dict = new Dictionary<string, object?>
+        {
+            ["PackageIdentifier"] = "Microsoft.PowerToys",
+            ["Installers"] = new List<object?>
+            {
+                new Dictionary<string, object?>
+                {
+                    ["InstallerType"] = "exe",
+                    ["InstallerSha256"] = "ABC",
+                }
+            },
+        };
+
+        var node = StructuredOutputSerializer.DynamicToJsonNode(dict);
+        var json = node!.ToJsonString();
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal("Microsoft.PowerToys", doc.RootElement.GetProperty("PackageIdentifier").GetString());
+        var installer = doc.RootElement.GetProperty("Installers")[0];
+        Assert.Equal("exe", installer.GetProperty("InstallerType").GetString());
+        Assert.Equal("ABC", installer.GetProperty("InstallerSha256").GetString());
+    }
+
+    [Fact]
+    public void DynamicToJsonNode_ExistingJsonNode_IsDeepCloned()
+    {
+        var source = new JsonObject { ["Name"] = "winget" };
+
+        var cloned = StructuredOutputSerializer.DynamicToJsonNode(source);
+
+        Assert.NotSame(source, cloned);
+        Assert.Equal("winget", (string?)cloned!["Name"]);
+
+        source["Name"] = "changed";
+        Assert.Equal("winget", (string?)cloned["Name"]);
+    }
+
+    [Fact]
+    public void JsonNodeToDynamic_Null_ReturnsNull()
+    {
+        Assert.Null(StructuredOutputSerializer.JsonNodeToDynamic(null));
+    }
+
+    [Fact]
+    public void JsonNodeToDynamic_JsonObject_ProducesStringDictionary()
+    {
+        var node = new JsonObject
+        {
+            ["Name"] = "winget",
+            ["Priority"] = 7,
+            ["Explicit"] = false,
+            ["LastUpdate"] = (JsonNode?)null,
+        };
+
+        var result = StructuredOutputSerializer.JsonNodeToDynamic(node);
+
+        var dict = Assert.IsType<Dictionary<string, object?>>(result);
+        Assert.Equal("winget", dict["Name"]);
+        Assert.Equal(7L, dict["Priority"]);
+        Assert.Equal(false, dict["Explicit"]);
+        Assert.Null(dict["LastUpdate"]);
+    }
+
+    [Fact]
+    public void JsonNodeToDynamic_JsonArray_ProducesObjectList()
+    {
+        var node = new JsonArray("a", 1, true);
+
+        var result = StructuredOutputSerializer.JsonNodeToDynamic(node);
+
+        var list = Assert.IsType<List<object?>>(result);
+        Assert.Equal(new object?[] { "a", 1L, true }, list);
+    }
+
+    [Fact]
+    public void JsonNodeToDynamic_Number_PrefersInt64WhenIntegral()
+    {
+        var node = JsonNode.Parse("42")!;
+        Assert.Equal(42L, StructuredOutputSerializer.JsonNodeToDynamic(node));
+    }
+
+    [Fact]
+    public void JsonNodeToDynamic_Number_FallsBackToDoubleWhenFractional()
+    {
+        var node = JsonNode.Parse("3.14")!;
+        Assert.Equal(3.14, (double)StructuredOutputSerializer.JsonNodeToDynamic(node)!, precision: 10);
+    }
+
+    [Fact]
+    public void JsonNodeToDynamic_OutputIsAcceptedByYamlDotNet()
+    {
+        // Regression: the settings YAML branch (WriteJsonNode in Program.cs)
+        // feeds the dynamic tree directly into YamlDotNet's serializer. Make
+        // sure the shape we produce is one YamlDotNet can render without
+        // throwing or emitting opaque CLR type names.
+        var input = new JsonObject
+        {
+            ["telemetry"] = new JsonObject { ["disable"] = true },
+            ["network"] = new JsonObject
+            {
+                ["downloader"] = "wininet",
+                ["doProgressTimeoutInSeconds"] = 60,
+            },
+            ["tags"] = new JsonArray("a", "b"),
+        };
+
+        var dynamic = StructuredOutputSerializer.JsonNodeToDynamic(input);
+        var yaml = new SerializerBuilder().Build().Serialize(dynamic!);
+
+        Assert.Contains("telemetry:", yaml);
+        Assert.Contains("disable: true", yaml);
+        Assert.Contains("doProgressTimeoutInSeconds: 60", yaml);
+        Assert.Contains("- a", yaml);
+        Assert.DoesNotContain("JsonElement", yaml);
+        Assert.DoesNotContain("System.", yaml);
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/YamlEmitterTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/YamlEmitterTests.cs
@@ -1,0 +1,155 @@
+using System.Text.Json.Nodes;
+using Devolutions.Pinget.Core;
+using Xunit;
+
+namespace Devolutions.Pinget.Core.Tests;
+
+public class YamlEmitterTests
+{
+    [Fact]
+    public void EmitDocument_Null_ProducesEmptyDocument()
+    {
+        // Null root maps to an empty document — no scalar value, no
+        // mapping, no sequence. The emitter still produces the document
+        // markers and a trailing newline.
+        var yaml = YamlEmitter.EmitDocument(null);
+        Assert.DoesNotContain("''", yaml);
+        Assert.DoesNotContain("null", yaml);
+    }
+
+    [Fact]
+    public void EmitDocument_PlainString_RoundsThroughCleanly()
+    {
+        // A regular alphabetic string emits as a plain scalar (no quotes).
+        // Matches YamlDotNet's high-level Serialize(string) behavior.
+        var yaml = YamlEmitter.EmitDocument("winget");
+        Assert.Contains("winget", yaml);
+        Assert.DoesNotContain("'winget'", yaml);
+    }
+
+    [Fact]
+    public void EmitDocument_Dictionary_ProducesBlockMapping()
+    {
+        var yaml = YamlEmitter.EmitDocument(new Dictionary<string, object?>
+        {
+            ["Name"] = "winget",
+            ["Priority"] = 0,
+            ["Explicit"] = false,
+        });
+
+        Assert.Contains("Name: winget", yaml);
+        Assert.Contains("Priority: 0", yaml);
+        Assert.Contains("Explicit: false", yaml);
+    }
+
+    [Fact]
+    public void EmitDocument_NestedListInDict_ProducesBlockSequence()
+    {
+        var yaml = YamlEmitter.EmitDocument(new Dictionary<string, object?>
+        {
+            ["Sources"] = new List<object?>
+            {
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = "a",
+                    ["Priority"] = 1,
+                },
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = "b",
+                    ["Priority"] = 2,
+                },
+            },
+        });
+
+        Assert.Contains("Sources:", yaml);
+        Assert.Contains("- Name: a", yaml);
+        Assert.Contains("- Name: b", yaml);
+    }
+
+    [Fact]
+    public void EmitDocument_EmptyList_ProducesFlowEmpty()
+    {
+        var yaml = YamlEmitter.EmitDocument(new Dictionary<string, object?>
+        {
+            ["Warnings"] = new List<object?>(),
+        });
+
+        Assert.Contains("Warnings: []", yaml);
+    }
+
+    [Fact]
+    public void EmitDocument_NullValueInDict_ProducesEmptyAfterColon()
+    {
+        // Reproduce YamlDotNet's high-level behavior: null mapping value
+        // becomes "key: " with no quotes, not "key: ''" — downstream
+        // parsers treat empty unquoted as null but '' as empty string.
+        var yaml = YamlEmitter.EmitDocument(new Dictionary<string, object?>
+        {
+            ["LastUpdate"] = (object?)null,
+            ["Name"] = "winget",
+        }).ReplaceLineEndings("\n");
+
+        Assert.Contains("LastUpdate: \n", yaml);
+        Assert.DoesNotContain("LastUpdate: ''", yaml);
+        Assert.Contains("Name: winget", yaml);
+    }
+
+    [Fact]
+    public void EmitDocument_JsonObject_FollowsPropertyOrder()
+    {
+        var node = new JsonObject
+        {
+            ["First"] = "1",
+            ["Second"] = "2",
+            ["Third"] = "3",
+        };
+
+        var yaml = YamlEmitter.EmitDocument(node);
+        var firstIdx = yaml.IndexOf("First");
+        var secondIdx = yaml.IndexOf("Second");
+        var thirdIdx = yaml.IndexOf("Third");
+
+        Assert.True(firstIdx >= 0 && secondIdx > firstIdx && thirdIdx > secondIdx,
+            "Properties should be emitted in declaration order");
+    }
+
+    [Fact]
+    public void EmitDocument_JsonObjectNullProperty_ProducesEmptyAfterColon()
+    {
+        var node = new JsonObject
+        {
+            ["Channel"] = null,
+            ["Name"] = "x",
+        };
+
+        var yaml = YamlEmitter.EmitDocument(node).ReplaceLineEndings("\n");
+
+        Assert.Contains("Channel: \n", yaml);
+        Assert.DoesNotContain("Channel: ''", yaml);
+        Assert.DoesNotContain("Channel: null", yaml);
+    }
+
+    [Fact]
+    public void EmitDocument_JsonArray_ProducesBlockSequence()
+    {
+        var node = JsonNode.Parse("""[ "a", 1, true, null ]""")!;
+        var yaml = YamlEmitter.EmitDocument(node);
+
+        Assert.Contains("- a", yaml);
+        Assert.Contains("- 1", yaml);
+        Assert.Contains("- true", yaml);
+    }
+
+    [Fact]
+    public void EmitDocument_DateTime_UsesRoundTripIsoFormat()
+    {
+        var dt = new DateTime(2026, 5, 26, 12, 34, 56, DateTimeKind.Utc);
+        var yaml = YamlEmitter.EmitDocument(new Dictionary<string, object?>
+        {
+            ["When"] = dt,
+        });
+
+        Assert.Contains("When: 2026-05-26T12:34:56", yaml);
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/YamlRoundtripTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/YamlRoundtripTests.cs
@@ -1,0 +1,134 @@
+using Devolutions.Pinget.Core;
+using Xunit;
+
+namespace Devolutions.Pinget.Core.Tests;
+
+public class YamlRoundtripTests
+{
+    [Fact]
+    public void SavePackagedStore_OutputIsLoadableByParsePackagedSourceStore()
+    {
+        // Regression: SavePackagedStore writes the sources state via
+        // YamlEmitter; ParsePackagedSourceStore reads it back through a
+        // hand-rolled line parser. Make sure the format the emitter
+        // produces is one the reader still recognises end-to-end.
+        var sourceDocumentYaml = YamlEmitter.EmitDocument(new Dictionary<string, object?>
+        {
+            ["Sources"] = new List<object?>
+            {
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = "winget",
+                    ["Type"] = "Microsoft.PreIndexed.Package",
+                    ["Arg"] = "https://cdn.winget.microsoft.com/cache",
+                    ["Data"] = "Microsoft.Winget.Source_8wekyb3d8bbwe",
+                    ["TrustLevel"] = "Trusted",
+                    ["Explicit"] = false,
+                    ["Priority"] = 0,
+                    ["IsTombstone"] = false,
+                },
+            },
+        });
+
+        var metadataDocumentYaml = YamlEmitter.EmitDocument(new Dictionary<string, object?>
+        {
+            ["Sources"] = new List<object?>
+            {
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = "winget",
+                    ["LastUpdate"] = 1700000000L,
+                    ["SourceVersion"] = "v2.0",
+                },
+            },
+        });
+
+        var store = SourceStoreManager.ParsePackagedSourceStore(sourceDocumentYaml, metadataDocumentYaml);
+
+        Assert.NotNull(store);
+        // ParsePackagedSourceStore merges the YAML entries on top of the
+        // hardcoded defaults, so we look up the specific source we wrote
+        // rather than asserting the total source count.
+        var source = Assert.Single(store!.Sources, s => string.Equals(s.Name, "winget", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(SourceKind.PreIndexed, source.Kind);
+        Assert.Equal("https://cdn.winget.microsoft.com/cache", source.Arg);
+        Assert.Equal("Microsoft.Winget.Source_8wekyb3d8bbwe", source.Identifier);
+        Assert.Equal("Trusted", source.TrustLevel);
+        Assert.False(source.Explicit);
+        Assert.Equal(0, source.Priority);
+        Assert.Equal("v2.0", source.SourceVersion);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1700000000L).UtcDateTime, source.LastUpdate);
+    }
+
+    [Fact]
+    public void ParseV2VersionDataDocument_ParsesAliasedKeys()
+    {
+        // The mszyml schema uses short aliases (v/rP/s256H/aMiV/aMaV).
+        // The new hand-rolled parser must honour those aliases to match
+        // what the old YamlDotNet DeserializerBuilder produced.
+        var yaml = """
+vD:
+  - v: 1.0.0
+    rP: manifests/m/microsoft/powertoys/1.0.0
+    s256H: abc123
+    aMiV: 1.0.0
+    aMaV: 1.0.0
+  - v: 2.0.0
+    rP: manifests/m/microsoft/powertoys/2.0.0
+    s256H: def456
+""";
+
+        var doc = PreIndexedSource.ParseV2VersionDataDocument(yaml);
+
+        Assert.NotNull(doc);
+        Assert.Equal(2, doc!.Versions.Count);
+
+        Assert.Equal("1.0.0", doc.Versions[0].Version);
+        Assert.Equal("manifests/m/microsoft/powertoys/1.0.0", doc.Versions[0].ManifestRelativePath);
+        Assert.Equal("abc123", doc.Versions[0].ManifestHash);
+        Assert.Equal("1.0.0", doc.Versions[0].ArpMinVersion);
+        Assert.Equal("1.0.0", doc.Versions[0].ArpMaxVersion);
+
+        Assert.Equal("2.0.0", doc.Versions[1].Version);
+        Assert.Equal("def456", doc.Versions[1].ManifestHash);
+        Assert.Null(doc.Versions[1].ArpMinVersion);
+        Assert.Null(doc.Versions[1].ArpMaxVersion);
+    }
+
+    [Fact]
+    public void ParseV2VersionDataDocument_IgnoresUnknownKeys()
+    {
+        // Reproduces the .IgnoreUnmatchedProperties() behaviour of the
+        // previous DeserializerBuilder configuration.
+        var yaml = """
+vD:
+  - v: 1.0.0
+    rP: x
+    s256H: y
+    unknownField: should-be-ignored
+  - v: 2.0.0
+    rP: z
+    s256H: w
+extraTopLevel:
+  ignoreMe: true
+""";
+
+        var doc = PreIndexedSource.ParseV2VersionDataDocument(yaml);
+
+        Assert.NotNull(doc);
+        Assert.Equal(2, doc!.Versions.Count);
+        Assert.Equal("1.0.0", doc.Versions[0].Version);
+        Assert.Equal("2.0.0", doc.Versions[1].Version);
+    }
+
+    [Fact]
+    public void ParseV2VersionDataDocument_EmptyDocument_ReturnsEmptyVersions()
+    {
+        var yaml = "vD: []\n";
+
+        var doc = PreIndexedSource.ParseV2VersionDataDocument(yaml);
+
+        Assert.NotNull(doc);
+        Assert.Empty(doc!.Versions);
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.Core/InstalledPackages.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/InstalledPackages.cs
@@ -187,12 +187,20 @@ internal static class InstalledPackages
                         var upgradeCode = subkey.GetValue("UpgradeCode") as string;
 
                         var localId = $@"ARP\{scopeLabel}\{effectiveArch}\{subkeyName}";
-                        var installerCategory = localId.StartsWith(@"ARP\", StringComparison.OrdinalIgnoreCase) &&
-                            subkey.GetValue("WindowsInstaller") is int windowsInstaller && windowsInstaller == 1
-                                ? "msi"
-                                : subkeyName.StartsWith("MSIX\\", StringComparison.OrdinalIgnoreCase)
-                                    ? "msix"
-                                    : "exe";
+                        // Honor the WinGet ARP signal so uninstall flows through the
+                        // portable uninstall path (clean dir + registry removal) instead
+                        // of delegating the UninstallString to a winget subprocess that
+                        // only fully cleans up entries winget itself installed.
+                        var wingetInstallerType = subkey.GetValue("WinGetInstallerType") as string;
+                        var installerCategory =
+                            wingetInstallerType is { } wit && wit.Equals("portable", StringComparison.OrdinalIgnoreCase)
+                                ? "portable"
+                                : localId.StartsWith(@"ARP\", StringComparison.OrdinalIgnoreCase) &&
+                                    subkey.GetValue("WindowsInstaller") is int windowsInstaller && windowsInstaller == 1
+                                    ? "msi"
+                                    : subkeyName.StartsWith("MSIX\\", StringComparison.OrdinalIgnoreCase)
+                                        ? "msix"
+                                        : "exe";
 
                         var dedupKey =
                             $"{localId}|{displayName.ToLowerInvariant()}|{version.ToLowerInvariant()}|{(publisher ?? "").ToLowerInvariant()}";

--- a/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
@@ -214,9 +214,17 @@ internal static class InstallerDispatch
         var installDirectoryCreated = !dirExisted || prevDirCreated;
 
         var installerType = installer.InstallerType ?? "";
+        string portableTargetFullPath;
         if (string.Equals(installerType, "zip", StringComparison.OrdinalIgnoreCase))
         {
             ZipFile.ExtractToDirectory(installerPath, targetDir, overwriteFiles: true);
+            // For nested-portable zips the binary lives at the RelativeFilePath
+            // the manifest declares. Record the first one as
+            // PortableTargetFullPath so winget's portable uninstall workflow can
+            // identify which file to remove.
+            portableTargetFullPath = installer.NestedInstallerFiles.Count > 0
+                ? Path.Combine(targetDir, installer.NestedInstallerFiles[0].RelativeFilePath)
+                : targetDir;
         }
         else
         {
@@ -226,10 +234,11 @@ internal static class InstallerDispatch
             var basename = Path.GetFileName(installerPath);
             if (string.IsNullOrWhiteSpace(basename))
                 throw new InvalidOperationException("portable installer has no filename");
-            File.Copy(installerPath, Path.Combine(targetDir, basename), overwrite: true);
+            portableTargetFullPath = Path.Combine(targetDir, basename);
+            File.Copy(installerPath, portableTargetFullPath, overwrite: true);
         }
 
-        WritePortableArpEntry(subkeyName, targetDir, installDirectoryCreated, sourceIdentifier, manifest);
+        WritePortableArpEntry(subkeyName, targetDir, portableTargetFullPath, installDirectoryCreated, sourceIdentifier, manifest);
         return 0;
     }
 
@@ -316,6 +325,7 @@ internal static class InstallerDispatch
     private static void WritePortableArpEntry(
         string subkeyName,
         string installLocation,
+        string portableTargetFullPath,
         bool installDirectoryCreated,
         string sourceIdentifier,
         Manifest manifest)
@@ -328,6 +338,7 @@ internal static class InstallerDispatch
         subkey.SetValue("WinGetSourceIdentifier", sourceIdentifier);
         subkey.SetValue("WinGetInstallerType", "portable");
         subkey.SetValue("InstallLocation", installLocation);
+        subkey.SetValue("PortableTargetFullPath", portableTargetFullPath);
         subkey.SetValue("InstallDirectoryCreated", installDirectoryCreated ? 1 : 0, Microsoft.Win32.RegistryValueKind.DWord);
         subkey.SetValue("DisplayName", string.IsNullOrEmpty(manifest.Name) ? manifest.Id : manifest.Name);
         subkey.SetValue("DisplayVersion", manifest.Version);

--- a/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
@@ -283,7 +283,7 @@ internal static class InstallerDispatch
     /// declare a command — the package still installs, just without a Links\
     /// shim.
     /// </summary>
-    private static string? DeterminePortableAlias(Installer installer)
+    internal static string? DeterminePortableAlias(Installer installer)
     {
         foreach (var file in installer.NestedInstallerFiles)
         {
@@ -392,6 +392,32 @@ internal static class InstallerDispatch
         catch { /* broadcast best-effort */ }
     }
 
+    /// <summary>
+    /// Case-insensitive, component-aware path-prefix check for Windows. A raw
+    /// <c>string.StartsWith</c> on the path strings would let <c>C:\Foo</c>
+    /// falsely match <c>C:\Foobar</c>; iterating path components avoids that.
+    /// Used by the Links\ sweep so an uninstall of one portable can't
+    /// accidentally delete shims that belong to a different portable whose
+    /// install dir happens to share a string prefix.
+    /// </summary>
+    internal static bool PathStartsWithCaseInsensitive(string child, string parent)
+    {
+        static string[] Components(string path) =>
+            path.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries)
+                .Select(p => p.ToLowerInvariant())
+                .ToArray();
+        var parentParts = Components(parent);
+        var childParts = Components(child);
+        if (parentParts.Length == 0 || parentParts.Length > childParts.Length)
+            return false;
+        for (int i = 0; i < parentParts.Length; i++)
+        {
+            if (!string.Equals(parentParts[i], childParts[i], StringComparison.Ordinal))
+                return false;
+        }
+        return true;
+    }
+
     private static class NativeMethods
     {
         [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
@@ -411,7 +437,7 @@ internal static class InstallerDispatch
     /// and <c>winget list</c> still finds the package; everything else uses
     /// the source name verbatim.
     /// </summary>
-    private static string PortableSourceIdentifier(PackageQuery query)
+    internal static string PortableSourceIdentifier(PackageQuery query)
     {
         var source = query.Source;
         if (string.IsNullOrEmpty(source) || string.Equals(source, "winget", StringComparison.OrdinalIgnoreCase))
@@ -419,7 +445,7 @@ internal static class InstallerDispatch
         return source;
     }
 
-    private static string PortableSubkeyName(string packageId, string sourceIdentifier) =>
+    internal static string PortableSubkeyName(string packageId, string sourceIdentifier) =>
         $"{packageId}_{sourceIdentifier}";
 
     private sealed record ExistingPortableEntry(string SubkeyName, string? InstallLocation, int? InstallDirectoryCreated);
@@ -454,20 +480,37 @@ internal static class InstallerDispatch
         return null;
     }
 
-    private static string ResolvePortableInstallLocation(InstallRequest request, ExistingPortableEntry? existing, string subkeyName)
+    private static string ResolvePortableInstallLocation(InstallRequest request, ExistingPortableEntry? existing, string subkeyName) =>
+        ResolvePortableInstallLocationPure(
+            request.InstallLocation,
+            existing?.InstallLocation,
+            subkeyName,
+            DefaultUserPortableRoot());
+
+    /// <summary>
+    /// Pure resolution rule for the portable install directory. Priority:
+    /// <c>requestLocation</c> (CLI override) → <c>existingLocation</c> (so
+    /// upgrades preserve a winget-installed location) → default user portable
+    /// root joined with the package's ARP subkey name.
+    /// </summary>
+    internal static string ResolvePortableInstallLocationPure(
+        string? requestLocation,
+        string? existingLocation,
+        string subkeyName,
+        string defaultUserPortableRoot)
     {
-        if (!string.IsNullOrWhiteSpace(request.InstallLocation))
-            return request.InstallLocation!;
-        if (!string.IsNullOrWhiteSpace(existing?.InstallLocation))
-            return existing!.InstallLocation!;
-        return Path.Combine(DefaultUserPortableRoot(), subkeyName);
+        if (!string.IsNullOrWhiteSpace(requestLocation))
+            return requestLocation!;
+        if (!string.IsNullOrWhiteSpace(existingLocation))
+            return existingLocation!;
+        return Path.Combine(defaultUserPortableRoot, subkeyName);
     }
 
     private static string DefaultUserPortableRoot() => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Microsoft", "WinGet", "Packages");
 
-    private static void CleanDirectoryContents(string dir)
+    internal static void CleanDirectoryContents(string dir)
     {
         if (!Directory.Exists(dir)) return;
         foreach (var entry in Directory.EnumerateFileSystemEntries(dir))
@@ -807,7 +850,6 @@ internal static class InstallerDispatch
                 "Microsoft", "WinGet", "Links");
             if (!Directory.Exists(linksRoot))
                 return;
-            var installPrefix = installLocation.ToLowerInvariant();
             foreach (var entry in Directory.EnumerateFiles(linksRoot))
             {
                 try
@@ -815,7 +857,7 @@ internal static class InstallerDispatch
                     var info = new FileInfo(entry);
                     var target = info.LinkTarget;
                     if (target is null) continue;
-                    if (target.ToLowerInvariant().StartsWith(installPrefix, StringComparison.Ordinal))
+                    if (PathStartsWithCaseInsensitive(target, installLocation))
                     {
                         try { File.Delete(entry); } catch { }
                     }

--- a/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
@@ -542,34 +542,91 @@ internal static class InstallerDispatch
         return args;
     }
 
+    [SupportedOSPlatform("windows")]
     private static int UninstallPortable(ListMatch installed, UninstallRequest request)
     {
         if (string.IsNullOrWhiteSpace(installed.InstallLocation))
         {
             if (request.Force)
+            {
+                TryRemovePortableRegistryEntry(installed);
                 return 0;
+            }
             throw new InvalidOperationException($"Portable package '{installed.Name}' does not expose an install location.");
         }
 
         if (request.Preserve)
             return 0;
 
+        var removed = false;
         if (Directory.Exists(installed.InstallLocation))
         {
             Directory.Delete(installed.InstallLocation, recursive: true);
-            return 0;
+            removed = true;
         }
-
-        if (File.Exists(installed.InstallLocation))
+        else if (File.Exists(installed.InstallLocation))
         {
             File.Delete(installed.InstallLocation);
+            removed = true;
+        }
+
+        if (removed || request.Force)
+        {
+            // Once the files are gone (or the user forced past missing files),
+            // drop the ARP entry too so the package no longer shows in lists.
+            TryRemovePortableRegistryEntry(installed);
             return 0;
         }
 
-        if (request.Force)
-            return 0;
-
         throw new InvalidOperationException($"Portable package location not found: {installed.InstallLocation}");
+    }
+
+    /// <summary>
+    /// Best-effort removal of the HKCU/HKLM ARP subkey backing a portable
+    /// entry. We match on LocalId (<c>ARP\&lt;scope&gt;\&lt;arch&gt;\&lt;subkey&gt;</c>) when
+    /// present so we delete the exact key the list view surfaced; otherwise we
+    /// walk the standard Uninstall path and match on WinGetPackageIdentifier.
+    /// Failures are swallowed because the file deletion already succeeded.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static void TryRemovePortableRegistryEntry(ListMatch installed)
+    {
+        try
+        {
+            const string ArpPrefix = @"ARP\";
+            if (installed.LocalId.StartsWith(ArpPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                var rest = installed.LocalId[ArpPrefix.Length..];
+                var parts = rest.Split('\\', 3);
+                if (parts.Length == 3 && !string.IsNullOrWhiteSpace(parts[2]))
+                {
+                    var hive = parts[0].Equals("User", StringComparison.OrdinalIgnoreCase)
+                        ? Microsoft.Win32.Registry.CurrentUser
+                        : Microsoft.Win32.Registry.LocalMachine;
+                    hive.DeleteSubKeyTree(
+                        $@"Software\Microsoft\Windows\CurrentVersion\Uninstall\{parts[2]}",
+                        throwOnMissingSubKey: false);
+                    return;
+                }
+            }
+
+            // Fall back: scan ARP by WinGetPackageIdentifier.
+            foreach (var hive in new[] { Microsoft.Win32.Registry.CurrentUser, Microsoft.Win32.Registry.LocalMachine })
+            {
+                using var uninstall = hive.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall", writable: true);
+                if (uninstall is null) continue;
+                foreach (var name in uninstall.GetSubKeyNames())
+                {
+                    using var subkey = uninstall.OpenSubKey(name);
+                    if (subkey is null) continue;
+                    if (string.Equals(subkey.GetValue("WinGetPackageIdentifier") as string, installed.Id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        try { uninstall.DeleteSubKeyTree(name, throwOnMissingSubKey: false); } catch { }
+                    }
+                }
+            }
+        }
+        catch { /* best-effort: file removal already succeeded */ }
     }
 
     private static string? DefaultExperienceSwitch(string installerType, InstallerMode mode) => mode switch

--- a/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
@@ -238,8 +238,171 @@ internal static class InstallerDispatch
             File.Copy(installerPath, portableTargetFullPath, overwrite: true);
         }
 
-        WritePortableArpEntry(subkeyName, targetDir, portableTargetFullPath, installDirectoryCreated, sourceIdentifier, manifest);
+        // Create the Links\<alias>.exe shim so users can invoke the portable from
+        // any shell, matching winget's portable workflow. Failures are non-fatal —
+        // when the user lacks SeCreateSymbolicLink (no Developer Mode, not admin)
+        // we still leave the package installed at install_location.
+        var alias = DeterminePortableAlias(installer);
+        var symlinkFullPath = string.IsNullOrEmpty(alias)
+            ? null
+            : TryCreatePortableSymlink(portableTargetFullPath, alias!);
+
+        // Ensure %LOCALAPPDATA%\Microsoft\WinGet\Links is on user PATH so the
+        // symlink we just created is resolvable from new shells. Tracks whether
+        // we added it this round so uninstall can decide whether to take it
+        // back out.
+        var addedToPath = symlinkFullPath is not null && TryAddLinksDirToUserPath();
+
+        WritePortableArpEntry(new PortableArpEntry(
+            SubkeyName: subkeyName,
+            InstallLocation: targetDir,
+            PortableTargetFullPath: portableTargetFullPath,
+            PortableSymlinkFullPath: symlinkFullPath,
+            InstallDirectoryCreated: installDirectoryCreated,
+            AddedToPath: addedToPath,
+            SourceIdentifier: sourceIdentifier,
+            Manifest: manifest));
         return 0;
+    }
+
+    private sealed record PortableArpEntry(
+        string SubkeyName,
+        string InstallLocation,
+        string PortableTargetFullPath,
+        string? PortableSymlinkFullPath,
+        bool InstallDirectoryCreated,
+        bool AddedToPath,
+        string SourceIdentifier,
+        Manifest Manifest);
+
+    /// <summary>
+    /// Picks the portable command alias from the manifest. Mirrors winget's
+    /// resolution: nested-installer files first (used by zip+portable
+    /// manifests), then the top-level <c>Commands</c> field (used by
+    /// standalone portable manifests). Returns null when the manifest doesn't
+    /// declare a command — the package still installs, just without a Links\
+    /// shim.
+    /// </summary>
+    private static string? DeterminePortableAlias(Installer installer)
+    {
+        foreach (var file in installer.NestedInstallerFiles)
+        {
+            if (!string.IsNullOrEmpty(file.PortableCommandAlias))
+                return file.PortableCommandAlias;
+        }
+        return installer.Commands.Count > 0 ? installer.Commands[0] : null;
+    }
+
+    private static string WingetLinksDir() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Microsoft", "WinGet", "Links");
+
+    /// <summary>
+    /// Creates (or replaces) <c>Links\&lt;alias&gt;.exe</c> as a symlink
+    /// pointing at the portable's binary. Returns the link path on success.
+    /// Returns null on any I/O failure (notably ERROR_PRIVILEGE_NOT_HELD when
+    /// the user lacks SeCreateSymbolicLink) so the install can still
+    /// complete without the shim.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static string? TryCreatePortableSymlink(string target, string alias)
+    {
+        try
+        {
+            var linksDir = WingetLinksDir();
+            Directory.CreateDirectory(linksDir);
+            var linkPath = Path.Combine(linksDir, $"{alias}.exe");
+
+            // Replace any prior link/file at the path so upgrades repoint to
+            // the new binary instead of leaving a stale symlink behind.
+            if (File.Exists(linkPath) || new FileInfo(linkPath).LinkTarget is not null)
+            {
+                try { File.Delete(linkPath); } catch { /* ignore */ }
+            }
+
+            File.CreateSymbolicLink(linkPath, target);
+            return linkPath;
+        }
+        catch
+        {
+            // Symlink creation requires Developer Mode or admin elevation.
+            // Treat any failure as non-fatal — the package files are already in
+            // place, just without a Links\ shim.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Adds <c>Links\</c> to the user's <c>HKCU\Environment\Path</c> if not
+    /// already present, then broadcasts WM_SETTINGCHANGE so explorer-spawned
+    /// shells pick up the new PATH without a logoff. Returns true if PATH was
+    /// actually appended this call.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static bool TryAddLinksDirToUserPath()
+    {
+        try
+        {
+            var linksDir = WingetLinksDir();
+            using var envKey = Microsoft.Win32.Registry.CurrentUser.OpenSubKey("Environment", writable: true);
+            if (envKey is null) return false;
+
+            var existing = envKey.GetValue("Path") as string ?? "";
+            var normalizedLinks = linksDir.ToLowerInvariant();
+            var alreadyPresent = existing
+                .Split(';')
+                .Any(c => c.Trim().Equals(normalizedLinks, StringComparison.OrdinalIgnoreCase));
+            if (alreadyPresent) return false;
+
+            string newPath;
+            if (existing.Length == 0)
+                newPath = linksDir;
+            else if (existing.EndsWith(';'))
+                newPath = existing + linksDir;
+            else
+                newPath = existing + ";" + linksDir;
+
+            envKey.SetValue("Path", newPath, Microsoft.Win32.RegistryValueKind.ExpandString);
+            BroadcastEnvironmentChange();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void BroadcastEnvironmentChange()
+    {
+        try
+        {
+            const uint HWND_BROADCAST = 0xFFFF;
+            const uint WM_SETTINGCHANGE = 0x001A;
+            const uint SMTO_ABORTIFHUNG = 0x0002;
+            _ = NativeMethods.SendMessageTimeoutW(
+                new IntPtr(unchecked((int)HWND_BROADCAST)),
+                WM_SETTINGCHANGE,
+                IntPtr.Zero,
+                "Environment",
+                SMTO_ABORTIFHUNG,
+                5000,
+                out _);
+        }
+        catch { /* broadcast best-effort */ }
+    }
+
+    private static class NativeMethods
+    {
+        [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr SendMessageTimeoutW(
+            IntPtr hWnd,
+            uint Msg,
+            IntPtr wParam,
+            string lParam,
+            uint fuFlags,
+            uint uTimeout,
+            out IntPtr lpdwResult);
     }
 
     /// <summary>
@@ -322,29 +485,27 @@ internal static class InstallerDispatch
     /// installed-package discovery actually read.
     /// </summary>
     [SupportedOSPlatform("windows")]
-    private static void WritePortableArpEntry(
-        string subkeyName,
-        string installLocation,
-        string portableTargetFullPath,
-        bool installDirectoryCreated,
-        string sourceIdentifier,
-        Manifest manifest)
+    private static void WritePortableArpEntry(PortableArpEntry entry)
     {
         using var subkey = Microsoft.Win32.Registry.CurrentUser
-            .CreateSubKey($@"Software\Microsoft\Windows\CurrentVersion\Uninstall\{subkeyName}")
+            .CreateSubKey($@"Software\Microsoft\Windows\CurrentVersion\Uninstall\{entry.SubkeyName}")
             ?? throw new InvalidOperationException("failed to create portable ARP registry subkey");
 
+        var manifest = entry.Manifest;
         subkey.SetValue("WinGetPackageIdentifier", manifest.Id);
-        subkey.SetValue("WinGetSourceIdentifier", sourceIdentifier);
+        subkey.SetValue("WinGetSourceIdentifier", entry.SourceIdentifier);
         subkey.SetValue("WinGetInstallerType", "portable");
-        subkey.SetValue("InstallLocation", installLocation);
-        subkey.SetValue("PortableTargetFullPath", portableTargetFullPath);
-        subkey.SetValue("InstallDirectoryCreated", installDirectoryCreated ? 1 : 0, Microsoft.Win32.RegistryValueKind.DWord);
+        subkey.SetValue("InstallLocation", entry.InstallLocation);
+        subkey.SetValue("PortableTargetFullPath", entry.PortableTargetFullPath);
+        if (!string.IsNullOrEmpty(entry.PortableSymlinkFullPath))
+            subkey.SetValue("PortableSymlinkFullPath", entry.PortableSymlinkFullPath);
+        subkey.SetValue("InstallDirectoryAddedToPath", entry.AddedToPath ? 1 : 0, Microsoft.Win32.RegistryValueKind.DWord);
+        subkey.SetValue("InstallDirectoryCreated", entry.InstallDirectoryCreated ? 1 : 0, Microsoft.Win32.RegistryValueKind.DWord);
         subkey.SetValue("DisplayName", string.IsNullOrEmpty(manifest.Name) ? manifest.Id : manifest.Name);
         subkey.SetValue("DisplayVersion", manifest.Version);
         if (!string.IsNullOrEmpty(manifest.Publisher))
             subkey.SetValue("Publisher", manifest.Publisher);
-        subkey.SetValue("UninstallString", $"winget uninstall --product-code {subkeyName}");
+        subkey.SetValue("UninstallString", $"winget uninstall --product-code {entry.SubkeyName}");
         subkey.SetValue("InstallDate", DateTime.UtcNow.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture));
         if (!string.IsNullOrEmpty(manifest.PackageUrl))
             subkey.SetValue("URLInfoAbout", manifest.PackageUrl);
@@ -545,10 +706,19 @@ internal static class InstallerDispatch
     [SupportedOSPlatform("windows")]
     private static int UninstallPortable(ListMatch installed, UninstallRequest request)
     {
+        // Read PortableSymlinkFullPath from the ARP entry *before* we touch the
+        // registry, so we can clean up winget-created shims in Links\. Without
+        // this, a portable that winget originally installed (with a
+        // PortableCommandAlias set in its manifest) would leave a dangling
+        // symlink in %LOCALAPPDATA%\Microsoft\WinGet\Links\ once pinget
+        // uninstalls it.
+        var knownSymlink = ReadPortableSymlinkFullPath(installed);
+
         if (string.IsNullOrWhiteSpace(installed.InstallLocation))
         {
             if (request.Force)
             {
+                TryRemovePortableSymlinks(knownSymlink, null);
                 TryRemovePortableRegistryEntry(installed);
                 return 0;
             }
@@ -573,12 +743,87 @@ internal static class InstallerDispatch
         if (removed || request.Force)
         {
             // Once the files are gone (or the user forced past missing files),
-            // drop the ARP entry too so the package no longer shows in lists.
+            // drop the symlink shim and ARP entry too so the package fully
+            // disappears.
+            TryRemovePortableSymlinks(knownSymlink, installed.InstallLocation);
             TryRemovePortableRegistryEntry(installed);
             return 0;
         }
 
         throw new InvalidOperationException($"Portable package location not found: {installed.InstallLocation}");
+    }
+
+    /// <summary>
+    /// Reads <c>PortableSymlinkFullPath</c> from the ARP subkey backing
+    /// <paramref name="installed"/> when present. winget writes this when it
+    /// created a <c>Links\&lt;alias&gt;.exe</c> shim for a portable; pinget's
+    /// own install_portable doesn't currently create shims, so for
+    /// pinget-installed entries this returns null.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static string? ReadPortableSymlinkFullPath(ListMatch installed)
+    {
+        const string ArpPrefix = @"ARP\";
+        if (!installed.LocalId.StartsWith(ArpPrefix, StringComparison.OrdinalIgnoreCase))
+            return null;
+        var rest = installed.LocalId[ArpPrefix.Length..];
+        var parts = rest.Split('\\', 3);
+        if (parts.Length != 3 || string.IsNullOrWhiteSpace(parts[2]))
+            return null;
+        var hive = parts[0].Equals("User", StringComparison.OrdinalIgnoreCase)
+            ? Microsoft.Win32.Registry.CurrentUser
+            : Microsoft.Win32.Registry.LocalMachine;
+        try
+        {
+            using var subkey = hive.OpenSubKey(
+                $@"Software\Microsoft\Windows\CurrentVersion\Uninstall\{parts[2]}");
+            return subkey?.GetValue("PortableSymlinkFullPath") as string;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// Removes the symlink shims winget would have created for this portable.
+    /// Tries (1) the exact path from <c>PortableSymlinkFullPath</c> if known,
+    /// and (2) any symlink in <c>%LOCALAPPDATA%\Microsoft\WinGet\Links\</c>
+    /// whose stored target resolves under the install location. Best-effort:
+    /// failures are swallowed.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static void TryRemovePortableSymlinks(string? knownSymlink, string? installLocation)
+    {
+        if (!string.IsNullOrWhiteSpace(knownSymlink))
+        {
+            try { File.Delete(knownSymlink!); } catch { }
+        }
+
+        if (string.IsNullOrWhiteSpace(installLocation))
+            return;
+
+        try
+        {
+            var linksRoot = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Microsoft", "WinGet", "Links");
+            if (!Directory.Exists(linksRoot))
+                return;
+            var installPrefix = installLocation.ToLowerInvariant();
+            foreach (var entry in Directory.EnumerateFiles(linksRoot))
+            {
+                try
+                {
+                    var info = new FileInfo(entry);
+                    var target = info.LinkTarget;
+                    if (target is null) continue;
+                    if (target.ToLowerInvariant().StartsWith(installPrefix, StringComparison.Ordinal))
+                    {
+                        try { File.Delete(entry); } catch { }
+                    }
+                }
+                catch { /* skip unreadable entry */ }
+            }
+        }
+        catch { /* best-effort */ }
     }
 
     /// <summary>

--- a/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/InstallerDispatch.cs
@@ -16,7 +16,8 @@ internal static class InstallerDispatch
         {
             "msi" or "wix" => RunMsi(installerPath, request, manifest, installer),
             "msix" or "appx" => RunMsix(installerPath),
-            "zip" when ShouldDelegatePortableZipInstall(request, manifest, installer) => InstallPortableWithWinget(request, manifest),
+            "zip" when IsPortableZipInstaller(installer) => InstallPortable(installerPath, request, manifest, installer),
+            "portable" => InstallPortable(installerPath, request, manifest, installer),
             "zip" => ExtractZip(installerPath),
             _ => RunExe(installerPath, installerType, request, manifest, installer)
         };
@@ -160,63 +161,182 @@ internal static class InstallerDispatch
         return 0;
     }
 
-    internal static bool ShouldDelegatePortableZipInstall(InstallRequest request, Manifest manifest, Installer installer) =>
-        IsPortableZipInstaller(installer) &&
-        !string.IsNullOrWhiteSpace(request.Query.Id ?? manifest.Id);
-
     internal static bool IsPortableZipInstaller(Installer installer) =>
-        installer.Commands.Count > 0 ||
         string.Equals(installer.NestedInstallerType, "portable", StringComparison.OrdinalIgnoreCase);
 
-    internal static List<string> BuildWingetPortableInstallArguments(InstallRequest request, Manifest manifest)
+    /// <summary>
+    /// Installs (or upgrades) a portable WinGet package natively. Mirrors the
+    /// Rust install_portable behavior so the C# and Rust pinget implementations
+    /// stay aligned (see AGENTS.md).
+    ///
+    /// Handles both <c>InstallerType: portable</c> (standalone binary) and
+    /// <c>InstallerType: zip</c> with <c>NestedInstallerType: portable</c> (the
+    /// shape every portable in the community winget catalog uses).
+    ///
+    /// Behavior follows winget's portable workflow closely enough that the
+    /// resulting HKCU ARP entry is recognized by <c>winget list</c> and by
+    /// pinget's own list view:
+    /// <list type="bullet">
+    ///   <item>Resolves the target install directory in this priority order:
+    ///   <c>request.InstallLocation</c>, existing <c>InstallLocation</c> from
+    ///   the registry ARP entry (so upgrades preserve a user's custom path),
+    ///   then WinGet's default user portable root.</item>
+    ///   <item>If an existing pinget-owned install lives in that directory
+    ///   (<c>InstallDirectoryCreated=1</c>), cleans its contents before
+    ///   extracting the new version.</item>
+    ///   <item>Extracts the zip (or copies the standalone binary), then writes
+    ///   the ARP registry entry both <c>winget list</c> and pinget read from.</item>
+    /// </list>
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static int InstallPortable(string installerPath, InstallRequest request, Manifest manifest, Installer installer)
     {
-        var packageId = request.Query.Id ?? manifest.Id;
-        var args = new List<string>
-        {
-            "install",
-            "--id",
-            packageId,
-            "--exact",
-            "--accept-source-agreements",
-            "--disable-interactivity",
-        };
+        var sourceIdentifier = PortableSourceIdentifier(request.Query);
+        var existingEntry = ReadExistingPortableEntry(manifest.Id);
+        // Reuse the existing subkey name on upgrade so we don't orphan the prior
+        // entry by writing to a different one.
+        var subkeyName = existingEntry?.SubkeyName ?? PortableSubkeyName(manifest.Id, sourceIdentifier);
 
-        if (!string.IsNullOrWhiteSpace(request.Query.Source))
+        var targetDir = ResolvePortableInstallLocation(request, existingEntry, subkeyName);
+
+        // If we created this directory on a previous install, wipe it clean so the
+        // new version doesn't co-exist with leftovers from the previous one. We
+        // do not touch a directory we don't own (InstallDirectoryCreated != 1).
+        var prevDirCreated = existingEntry?.InstallDirectoryCreated == 1;
+        var dirExisted = Directory.Exists(targetDir);
+        if (prevDirCreated && dirExisted)
+            CleanDirectoryContents(targetDir);
+
+        Directory.CreateDirectory(targetDir);
+        // "We created it" is sticky across upgrades: if a previous install
+        // marked it created, it still counts as created by us even when the
+        // dir already existed this round.
+        var installDirectoryCreated = !dirExisted || prevDirCreated;
+
+        var installerType = installer.InstallerType ?? "";
+        if (string.Equals(installerType, "zip", StringComparison.OrdinalIgnoreCase))
         {
-            args.Add("--source");
-            args.Add(request.Query.Source!);
+            ZipFile.ExtractToDirectory(installerPath, targetDir, overwriteFiles: true);
+        }
+        else
+        {
+            // Standalone portable: copy the downloaded file into targetDir using
+            // its original filename. winget would optionally rename to the
+            // PortableCommandAlias; pinget keeps the original name for now.
+            var basename = Path.GetFileName(installerPath);
+            if (string.IsNullOrWhiteSpace(basename))
+                throw new InvalidOperationException("portable installer has no filename");
+            File.Copy(installerPath, Path.Combine(targetDir, basename), overwrite: true);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Query.Version))
-        {
-            args.Add("--version");
-            args.Add(request.Query.Version!);
-        }
-
-        if (!string.IsNullOrWhiteSpace(request.Query.InstallScope))
-        {
-            args.Add("--scope");
-            args.Add(request.Query.InstallScope!);
-        }
-
-        if (request.AcceptPackageAgreements)
-            args.Add("--accept-package-agreements");
-
-        if (request.Mode == InstallerMode.Silent || request.Mode == InstallerMode.SilentWithProgress)
-            args.Add("--silent");
-
-        return args;
+        WritePortableArpEntry(subkeyName, targetDir, installDirectoryCreated, sourceIdentifier, manifest);
+        return 0;
     }
 
-    private static int InstallPortableWithWinget(InstallRequest request, Manifest manifest)
+    /// <summary>
+    /// Source identifier embedded in the ARP subkey name. We mirror winget for
+    /// the community repo so winget's UninstallString can resolve the subkey
+    /// and <c>winget list</c> still finds the package; everything else uses
+    /// the source name verbatim.
+    /// </summary>
+    private static string PortableSourceIdentifier(PackageQuery query)
     {
-        var psi = new ProcessStartInfo("winget") { UseShellExecute = false };
-        foreach (var arg in BuildWingetPortableInstallArguments(request, manifest))
-            psi.ArgumentList.Add(arg);
+        var source = query.Source;
+        if (string.IsNullOrEmpty(source) || string.Equals(source, "winget", StringComparison.OrdinalIgnoreCase))
+            return "Microsoft.Winget.Source_8wekyb3d8bbwe";
+        return source;
+    }
 
-        using var proc = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start winget for portable install");
-        proc.WaitForExit();
-        return proc.ExitCode;
+    private static string PortableSubkeyName(string packageId, string sourceIdentifier) =>
+        $"{packageId}_{sourceIdentifier}";
+
+    private sealed record ExistingPortableEntry(string SubkeyName, string? InstallLocation, int? InstallDirectoryCreated);
+
+    [SupportedOSPlatform("windows")]
+    private static ExistingPortableEntry? ReadExistingPortableEntry(string packageId)
+    {
+        using var uninstall = Microsoft.Win32.Registry.CurrentUser
+            .OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Uninstall");
+        if (uninstall is null) return null;
+
+        foreach (var name in uninstall.GetSubKeyNames())
+        {
+            using var subkey = uninstall.OpenSubKey(name);
+            if (subkey is null) continue;
+
+            if (!string.Equals(subkey.GetValue("WinGetPackageIdentifier") as string, packageId, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (!string.Equals(subkey.GetValue("WinGetInstallerType") as string, "portable", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            int? installDirectoryCreated = subkey.GetValue("InstallDirectoryCreated") switch
+            {
+                int i => i,
+                _ => null,
+            };
+            return new ExistingPortableEntry(
+                SubkeyName: name,
+                InstallLocation: subkey.GetValue("InstallLocation") as string,
+                InstallDirectoryCreated: installDirectoryCreated);
+        }
+        return null;
+    }
+
+    private static string ResolvePortableInstallLocation(InstallRequest request, ExistingPortableEntry? existing, string subkeyName)
+    {
+        if (!string.IsNullOrWhiteSpace(request.InstallLocation))
+            return request.InstallLocation!;
+        if (!string.IsNullOrWhiteSpace(existing?.InstallLocation))
+            return existing!.InstallLocation!;
+        return Path.Combine(DefaultUserPortableRoot(), subkeyName);
+    }
+
+    private static string DefaultUserPortableRoot() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Microsoft", "WinGet", "Packages");
+
+    private static void CleanDirectoryContents(string dir)
+    {
+        if (!Directory.Exists(dir)) return;
+        foreach (var entry in Directory.EnumerateFileSystemEntries(dir))
+        {
+            if (Directory.Exists(entry))
+                Directory.Delete(entry, recursive: true);
+            else
+                File.Delete(entry);
+        }
+    }
+
+    /// <summary>
+    /// Writes the HKCU ARP entry winget would normally write for a portable
+    /// install. Only the subset that winget's portable list view and pinget's
+    /// installed-package discovery actually read.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static void WritePortableArpEntry(
+        string subkeyName,
+        string installLocation,
+        bool installDirectoryCreated,
+        string sourceIdentifier,
+        Manifest manifest)
+    {
+        using var subkey = Microsoft.Win32.Registry.CurrentUser
+            .CreateSubKey($@"Software\Microsoft\Windows\CurrentVersion\Uninstall\{subkeyName}")
+            ?? throw new InvalidOperationException("failed to create portable ARP registry subkey");
+
+        subkey.SetValue("WinGetPackageIdentifier", manifest.Id);
+        subkey.SetValue("WinGetSourceIdentifier", sourceIdentifier);
+        subkey.SetValue("WinGetInstallerType", "portable");
+        subkey.SetValue("InstallLocation", installLocation);
+        subkey.SetValue("InstallDirectoryCreated", installDirectoryCreated ? 1 : 0, Microsoft.Win32.RegistryValueKind.DWord);
+        subkey.SetValue("DisplayName", string.IsNullOrEmpty(manifest.Name) ? manifest.Id : manifest.Name);
+        subkey.SetValue("DisplayVersion", manifest.Version);
+        if (!string.IsNullOrEmpty(manifest.Publisher))
+            subkey.SetValue("Publisher", manifest.Publisher);
+        subkey.SetValue("UninstallString", $"winget uninstall --product-code {subkeyName}");
+        subkey.SetValue("InstallDate", DateTime.UtcNow.ToString("yyyyMMdd", System.Globalization.CultureInfo.InvariantCulture));
+        if (!string.IsNullOrEmpty(manifest.PackageUrl))
+            subkey.SetValue("URLInfoAbout", manifest.PackageUrl);
     }
 
     private static int RunExe(string path, string installerType, InstallRequest request, Manifest manifest, Installer installer)

--- a/dotnet/src/Devolutions.Pinget.Core/Models.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Models.cs
@@ -681,12 +681,26 @@ internal static class StructuredOutput
         return document;
     }
 
+    public static Dictionary<string, object?> NestedInstallerFileDocument(NestedInstallerFile file)
+    {
+        var document = new Dictionary<string, object?>
+        {
+            ["RelativeFilePath"] = file.RelativeFilePath,
+        };
+        AddString(document, "PortableCommandAlias", file.PortableCommandAlias);
+        return document;
+    }
+
     public static Dictionary<string, object?> InstallerDocument(Installer installer)
     {
         var document = new Dictionary<string, object?>();
         AddString(document, "Architecture", installer.Architecture);
         AddString(document, "InstallerType", installer.InstallerType);
         AddString(document, "NestedInstallerType", installer.NestedInstallerType);
+        if (installer.NestedInstallerFiles.Count > 0)
+            document["NestedInstallerFiles"] = installer.NestedInstallerFiles
+                .Select(NestedInstallerFileDocument)
+                .ToList();
         AddString(document, "InstallerUrl", installer.Url);
         AddString(document, "InstallerSha256", installer.Sha256);
         AddString(document, "ProductCode", installer.ProductCode);

--- a/dotnet/src/Devolutions.Pinget.Core/Models.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Models.cs
@@ -189,6 +189,7 @@ public record Installer
     public string? Architecture { get; init; }
     public string? InstallerType { get; init; }
     public string? NestedInstallerType { get; init; }
+    public List<NestedInstallerFile> NestedInstallerFiles { get; init; } = [];
     public string? Url { get; init; }
     public string? Sha256 { get; init; }
     public string? ProductCode { get; init; }
@@ -203,6 +204,17 @@ public record Installer
     public List<string> Commands { get; init; } = [];
     public List<string> PackageDependencies { get; init; } = [];
     public bool RequireExplicitUpgrade { get; init; }
+}
+
+public record NestedInstallerFile
+{
+    /// <summary>Path to the executable within the extracted archive.</summary>
+    public required string RelativeFilePath { get; init; }
+    /// <summary>
+    /// Optional alias winget exposes for portable invocation. Pinget records
+    /// it for parity but doesn't yet create symlinks / PATH entries.
+    /// </summary>
+    public string? PortableCommandAlias { get; init; }
 }
 
 public record InstallerSwitches
@@ -413,6 +425,7 @@ public record SerializableInstaller
     public string? Architecture { get; init; }
     public string? InstallerType { get; init; }
     public string? NestedInstallerType { get; init; }
+    public List<NestedInstallerFile> NestedInstallerFiles { get; init; } = [];
     public string? InstallerUrl { get; init; }
     public string? InstallerSha256 { get; init; }
     public string? ProductCode { get; init; }
@@ -432,6 +445,7 @@ public record SerializableInstaller
         Architecture = installer.Architecture,
         InstallerType = installer.InstallerType,
         NestedInstallerType = installer.NestedInstallerType,
+        NestedInstallerFiles = installer.NestedInstallerFiles,
         InstallerUrl = installer.Url,
         InstallerSha256 = installer.Sha256,
         ProductCode = installer.ProductCode,

--- a/dotnet/src/Devolutions.Pinget.Core/Models.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Models.cs
@@ -465,6 +465,10 @@ public record SerializableInstaller
 [JsonSerializable(typeof(List<SerializableShowManifest>))]
 [JsonSerializable(typeof(RepositoryWarning))]
 [JsonSerializable(typeof(List<RepositoryWarning>))]
+[JsonSerializable(typeof(SearchResponse))]
+[JsonSerializable(typeof(ListResponse))]
+[JsonSerializable(typeof(VersionsResult))]
+[JsonSerializable(typeof(CacheWarmResult))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 public partial class PingetJsonContext : JsonSerializerContext;
 

--- a/dotnet/src/Devolutions.Pinget.Core/Models.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Models.cs
@@ -211,8 +211,7 @@ public record NestedInstallerFile
     /// <summary>Path to the executable within the extracted archive.</summary>
     public required string RelativeFilePath { get; init; }
     /// <summary>
-    /// Optional alias winget exposes for portable invocation. Pinget records
-    /// it for parity but doesn't yet create symlinks / PATH entries.
+    /// Optional alias exposed for portable invocation.
     /// </summary>
     public string? PortableCommandAlias { get; init; }
 }

--- a/dotnet/src/Devolutions.Pinget.Core/PreIndexedSource.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/PreIndexedSource.cs
@@ -1,5 +1,7 @@
 using System.IO.Compression;
 using Microsoft.Data.Sqlite;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 
 namespace Devolutions.Pinget.Core;
 
@@ -220,14 +222,151 @@ internal static class PreIndexedSource
         var bytes = GetCachedSourceFile(client, "V2_PVD", source, relativePath, packageHash);
         var yaml = DecompressMszyml(bytes);
 
-        var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
-            .IgnoreUnmatchedProperties()
-            .Build();
-        var doc = deserializer.Deserialize<V2VersionDataDocument>(yaml)
+        var doc = ParseV2VersionDataDocument(yaml)
             ?? throw new InvalidOperationException("Failed to parse versionData.mszyml");
 
         var cacheDir = TempCachePath("V2_PVD", source.Identifier);
         return (doc.Versions, Path.Combine(cacheDir, relativePath.Replace('/', '\\')));
+    }
+
+    // Hand-rolled YAML parser for versionData.mszyml. Replaces the
+    // reflection-based DeserializerBuilder path, which trips IL3050 under
+    // NativeAOT. The schema is fully known (top-level mapping with a single
+    // `vD` sequence of entries, each with v/rP/s256H/aMiV/aMaV keys), so we
+    // walk it with the low-level Parser. Unknown keys are silently skipped
+    // — same behavior as the prior `.IgnoreUnmatchedProperties()` setting.
+    internal static V2VersionDataDocument? ParseV2VersionDataDocument(string yaml)
+    {
+        var parser = new Parser(new StringReader(yaml));
+        if (!parser.Accept<StreamStart>(out _))
+            return null;
+        parser.Consume<StreamStart>();
+        if (!parser.Accept<DocumentStart>(out _))
+            return null;
+        parser.Consume<DocumentStart>();
+
+        var document = new V2VersionDataDocument();
+        if (parser.Current is MappingStart)
+        {
+            parser.MoveNext();
+            while (parser.Current is not MappingEnd)
+            {
+                var key = ConsumeScalar(parser);
+                if (string.Equals(key, "vD", StringComparison.Ordinal))
+                    document.Versions = ReadV2VersionEntries(parser);
+                else
+                    SkipNode(parser);
+            }
+            parser.MoveNext();
+        }
+        else
+        {
+            SkipNode(parser);
+        }
+
+        return document;
+    }
+
+    private static List<V2VersionDataEntry> ReadV2VersionEntries(IParser parser)
+    {
+        var entries = new List<V2VersionDataEntry>();
+        if (parser.Current is not SequenceStart)
+        {
+            SkipNode(parser);
+            return entries;
+        }
+
+        parser.MoveNext();
+        while (parser.Current is not SequenceEnd)
+        {
+            if (parser.Current is MappingStart)
+                entries.Add(ReadV2VersionEntry(parser));
+            else
+                SkipNode(parser);
+        }
+        parser.MoveNext();
+        return entries;
+    }
+
+    private static V2VersionDataEntry ReadV2VersionEntry(IParser parser)
+    {
+        var entry = new V2VersionDataEntry();
+        parser.Consume<MappingStart>();
+        while (parser.Current is not MappingEnd)
+        {
+            var key = ConsumeScalar(parser);
+            var value = parser.Current is Scalar s ? ScalarValueOrNull(s) : null;
+            if (parser.Current is Scalar)
+            {
+                parser.MoveNext();
+            }
+            else
+            {
+                SkipNode(parser);
+                continue;
+            }
+
+            switch (key)
+            {
+                case "v": entry.Version = value ?? ""; break;
+                case "rP": entry.ManifestRelativePath = value ?? ""; break;
+                case "s256H": entry.ManifestHash = value ?? ""; break;
+                case "aMiV": entry.ArpMinVersion = value; break;
+                case "aMaV": entry.ArpMaxVersion = value; break;
+                default: break;
+            }
+        }
+        parser.MoveNext();
+        return entry;
+    }
+
+    private static string ConsumeScalar(IParser parser)
+    {
+        var scalar = parser.Consume<Scalar>();
+        return scalar.Value;
+    }
+
+    private static string? ScalarValueOrNull(Scalar scalar)
+    {
+        if (scalar.Tag.IsEmpty && scalar.Style == ScalarStyle.Plain)
+        {
+            var v = scalar.Value;
+            if (v.Length == 0 || v == "~" ||
+                v.Equals("null", StringComparison.OrdinalIgnoreCase) ||
+                v.Equals("Null", StringComparison.Ordinal))
+            {
+                return null;
+            }
+        }
+        return scalar.Value;
+    }
+
+    private static void SkipNode(IParser parser)
+    {
+        switch (parser.Current)
+        {
+            case Scalar:
+                parser.MoveNext();
+                return;
+            case MappingStart:
+                parser.MoveNext();
+                while (parser.Current is not MappingEnd)
+                {
+                    SkipNode(parser); // key
+                    SkipNode(parser); // value
+                }
+                parser.MoveNext();
+                return;
+            case SequenceStart:
+                parser.MoveNext();
+                while (parser.Current is not SequenceEnd)
+                    SkipNode(parser);
+                parser.MoveNext();
+                return;
+            default:
+                parser.MoveNext();
+                return;
+        }
     }
 
     public static byte[] GetCachedSourceFile(

--- a/dotnet/src/Devolutions.Pinget.Core/Repository.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Repository.cs
@@ -1516,6 +1516,9 @@ public class Repository : IDisposable
         // Top-level installer defaults (merged manifest format)
         string? topInstallerType = GetOptStr("InstallerType");
         string? topNestedInstallerType = GetOptStr("NestedInstallerType");
+        var topNestedInstallerFiles = dict.TryGetValue("NestedInstallerFiles", out var topNestedFilesValue)
+            ? ReadNestedInstallerFiles(topNestedFilesValue)
+            : [];
         string? topScope = GetOptStr("Scope");
         string? topProductCode = GetOptStr("ProductCode");
         string? topLocale = GetOptStr("InstallerLocale");
@@ -1548,11 +1551,15 @@ public class Repository : IDisposable
                         ? ReadStringList(platformValue)
                         : [];
 
+                    var nestedFiles = instDict.TryGetValue("NestedInstallerFiles", out var nestedFilesValue)
+                        ? ReadNestedInstallerFiles(nestedFilesValue)
+                        : [];
                     installers.Add(new Installer
                     {
                         Architecture = InstStr("Architecture"),
                         InstallerType = InstStr("InstallerType") ?? topInstallerType,
                         NestedInstallerType = InstStr("NestedInstallerType") ?? topNestedInstallerType,
+                        NestedInstallerFiles = nestedFiles.Count > 0 ? nestedFiles : [.. topNestedInstallerFiles],
                         Url = InstStr("InstallerUrl"),
                         Sha256 = InstStr("InstallerSha256"),
                         ProductCode = InstStr("ProductCode") ?? topProductCode,
@@ -1841,6 +1848,30 @@ public class Repository : IDisposable
 
     private static string? GetDocumentString(Dictionary<string, object?> source, string key) =>
         source.TryGetValue(key, out var value) ? value?.ToString() : null;
+
+    private static List<NestedInstallerFile> ReadNestedInstallerFiles(object? value)
+    {
+        if (value is not IList<object> list)
+            return [];
+
+        var files = new List<NestedInstallerFile>();
+        foreach (var entry in list)
+        {
+            if (entry is not IDictionary<object, object> dict)
+                continue;
+
+            var relative = dict.TryGetValue("RelativeFilePath", out var rel) ? rel?.ToString() : null;
+            if (string.IsNullOrWhiteSpace(relative))
+                continue;
+
+            files.Add(new NestedInstallerFile
+            {
+                RelativeFilePath = relative!,
+                PortableCommandAlias = dict.TryGetValue("PortableCommandAlias", out var alias) ? alias?.ToString() : null,
+            });
+        }
+        return files;
+    }
 
     private static List<PackageAgreement> ReadAgreements(IDictionary<string, object?> values)
     {

--- a/dotnet/src/Devolutions.Pinget.Core/Repository.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Repository.cs
@@ -71,6 +71,10 @@ public class Repository : IDisposable
         yield return Path.Combine(assemblyDirectory, "runtimes", rid, "native", "e_sqlite3.dll");
     }
 
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(
+        "SingleFile",
+        "IL3000:Assembly.Location returns an empty string for assemblies embedded in a single-file app",
+        Justification = "We fall back to AppContext.BaseDirectory when Assembly.Location is empty. The Assembly.Location probe is needed for the PowerShell-module deployment, where Core.dll sits next to runtimes/<rid>/native/e_sqlite3.dll inside the module while the host process (pwsh.exe) has a different base directory.")]
     private static void EnsureSqliteNativeLibraryLoaded()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -80,6 +84,8 @@ public class Repository : IDisposable
             return;
 
         var assemblyDirectory = Path.GetDirectoryName(typeof(Repository).Assembly.Location);
+        if (string.IsNullOrWhiteSpace(assemblyDirectory))
+            assemblyDirectory = AppContext.BaseDirectory;
         if (string.IsNullOrWhiteSpace(assemblyDirectory))
             return;
 

--- a/dotnet/src/Devolutions.Pinget.Core/RestSource.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/RestSource.cs
@@ -281,6 +281,26 @@ internal static class RestSource
             return v.EnumerateArray().Select(x => x.GetString() ?? "").Where(s => s != "").ToList();
         }
 
+        List<NestedInstallerFile> ReadNestedInstallerFilesJson(JsonElement el)
+        {
+            if (!el.TryGetProperty("NestedInstallerFiles", out var v) || v.ValueKind != JsonValueKind.Array)
+                return [];
+
+            var result = new List<NestedInstallerFile>();
+            foreach (var entry in v.EnumerateArray())
+            {
+                if (entry.ValueKind != JsonValueKind.Object) continue;
+                var relative = GetOptStr(entry, "RelativeFilePath");
+                if (string.IsNullOrWhiteSpace(relative)) continue;
+                result.Add(new NestedInstallerFile
+                {
+                    RelativeFilePath = relative!,
+                    PortableCommandAlias = GetOptStr(entry, "PortableCommandAlias"),
+                });
+            }
+            return result;
+        }
+
         List<string> GetPackageDependencies(JsonElement el)
         {
             var direct = GetStrArray(el, "PackageDependencies");
@@ -338,11 +358,15 @@ internal static class RestSource
         {
             foreach (var inst in instArr.EnumerateArray())
             {
+                var nestedFiles = ReadNestedInstallerFilesJson(inst);
+                if (nestedFiles.Count == 0)
+                    nestedFiles = ReadNestedInstallerFilesJson(data);
                 installers.Add(new Installer
                 {
                     Architecture = GetOptStr(inst, "Architecture"),
                     InstallerType = GetOptStr(inst, "InstallerType"),
                     NestedInstallerType = GetOptStr(inst, "NestedInstallerType") ?? GetOptStr(data, "NestedInstallerType"),
+                    NestedInstallerFiles = nestedFiles,
                     Url = GetOptStr(inst, "InstallerUrl"),
                     Sha256 = GetOptStr(inst, "InstallerSha256"),
                     ProductCode = GetOptStr(inst, "ProductCode"),

--- a/dotnet/src/Devolutions.Pinget.Core/RestSource.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/RestSource.cs
@@ -164,7 +164,7 @@ internal static class RestSource
         var filters = new JsonArray();
         void AddFilter(string field, string value, string matchType)
         {
-            filters.Add(new JsonObject
+            filters.Add((JsonNode?)new JsonObject
             {
                 ["PackageMatchField"] = field,
                 ["RequestMatch"] = new JsonObject
@@ -210,7 +210,7 @@ internal static class RestSource
         if (info.RequiredPackageMatchFields.Any(f => f.Equals("market", StringComparison.OrdinalIgnoreCase)))
         {
             var market = Environment.GetEnvironmentVariable("WINGET_DOTNET_MARKET") ?? "US";
-            filters.Add(new JsonObject
+            filters.Add((JsonNode?)new JsonObject
             {
                 ["PackageMatchField"] = "Market",
                 ["RequestMatch"] = new JsonObject

--- a/dotnet/src/Devolutions.Pinget.Core/SourceStore.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/SourceStore.cs
@@ -2,8 +2,6 @@ using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Devolutions.Pinget.Core;
 
@@ -262,10 +260,6 @@ internal static class SourceStoreManager
 
     private static void SavePackagedStore(string root, SourceStore store)
     {
-        var serializer = new SerializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .Build();
-
         var sourceDocument = new Dictionary<string, object?>
         {
             ["Sources"] = store.Sources.Select(source => new Dictionary<string, object?>
@@ -297,9 +291,9 @@ internal static class SourceStoreManager
         var userSourcesDirectory = Path.GetDirectoryName(userSourcesPath);
         if (!string.IsNullOrWhiteSpace(userSourcesDirectory))
             Directory.CreateDirectory(userSourcesDirectory);
-        File.WriteAllText(userSourcesPath, serializer.Serialize(sourceDocument));
+        File.WriteAllText(userSourcesPath, YamlEmitter.EmitDocument(sourceDocument));
 
-        File.WriteAllText(Path.Combine(root, PackagedMetadataFileName), serializer.Serialize(metadataDocument));
+        File.WriteAllText(Path.Combine(root, PackagedMetadataFileName), YamlEmitter.EmitDocument(metadataDocument));
     }
 
     private static bool TryGetPackagedLocalStateRoot(string root, out string localStateRoot)

--- a/dotnet/src/Devolutions.Pinget.Core/YamlEmitter.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/YamlEmitter.cs
@@ -1,0 +1,237 @@
+using System.Collections;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace Devolutions.Pinget.Core;
+
+// Hand-rolled YAML emitter built on YamlDotNet's low-level event API. The
+// high-level SerializerBuilder is reflection-based and trips IL3050 under
+// NativeAOT; the Emitter is event-driven and AOT-safe. Inputs accepted:
+// JsonNode, IDictionary<string,object?>, IEnumerable, strings, booleans,
+// numeric primitives, and DateTime/DateTimeOffset/Guid. Unknown values are
+// rendered via ToString() — matches what the reflection-based serializer
+// would do for opaque types.
+public static class YamlEmitter
+{
+    public static string EmitDocument(object? value)
+    {
+        using var writer = new StringWriter();
+        EmitDocument(value, writer);
+        return writer.ToString();
+    }
+
+    public static void EmitDocument(object? value, TextWriter writer)
+    {
+        var emitter = new Emitter(writer);
+        emitter.Emit(new StreamStart());
+        emitter.Emit(new DocumentStart());
+        EmitNode(emitter, value);
+        emitter.Emit(new DocumentEnd(isImplicit: true));
+        emitter.Emit(new StreamEnd());
+    }
+
+    private static void EmitNode(IEmitter emitter, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                EmitNull(emitter);
+                return;
+
+            case JsonNode node:
+                EmitJsonNode(emitter, node);
+                return;
+
+            case string s:
+                EmitScalar(emitter, s);
+                return;
+
+            case bool b:
+                EmitScalar(emitter, b ? "true" : "false");
+                return;
+
+            case sbyte or byte or short or ushort or int or uint or long or ulong:
+                EmitScalar(emitter, Convert.ToString(value, CultureInfo.InvariantCulture) ?? "");
+                return;
+
+            case float f:
+                EmitScalar(emitter, f.ToString("R", CultureInfo.InvariantCulture));
+                return;
+
+            case double d:
+                EmitScalar(emitter, d.ToString("R", CultureInfo.InvariantCulture));
+                return;
+
+            case decimal m:
+                EmitScalar(emitter, m.ToString(CultureInfo.InvariantCulture));
+                return;
+
+            case DateTime dt:
+                EmitScalar(emitter, dt.ToString("o", CultureInfo.InvariantCulture));
+                return;
+
+            case DateTimeOffset dto:
+                EmitScalar(emitter, dto.ToString("o", CultureInfo.InvariantCulture));
+                return;
+
+            case Guid g:
+                EmitScalar(emitter, g.ToString("D", CultureInfo.InvariantCulture));
+                return;
+
+            case IDictionary<string, object?> stringDict:
+                EmitMapping(emitter, stringDict);
+                return;
+
+            case IDictionary dict:
+                EmitMapping(emitter, dict);
+                return;
+
+            case IEnumerable enumerable:
+                EmitSequence(emitter, enumerable);
+                return;
+
+            default:
+                EmitScalar(emitter, value.ToString() ?? "");
+                return;
+        }
+    }
+
+    private static void EmitJsonNode(IEmitter emitter, JsonNode? node)
+    {
+        switch (node)
+        {
+            case null:
+                EmitNull(emitter);
+                return;
+
+            case JsonObject obj:
+                emitter.Emit(new MappingStart(anchor: null, tag: null, isImplicit: true, style: MappingStyle.Block));
+                foreach (var (key, child) in obj)
+                {
+                    EmitScalar(emitter, key);
+                    EmitJsonNode(emitter, child);
+                }
+                emitter.Emit(new MappingEnd());
+                return;
+
+            case JsonArray array:
+                if (array.Count == 0)
+                {
+                    emitter.Emit(new SequenceStart(anchor: null, tag: null, isImplicit: true, style: SequenceStyle.Flow));
+                    emitter.Emit(new SequenceEnd());
+                    return;
+                }
+                emitter.Emit(new SequenceStart(anchor: null, tag: null, isImplicit: true, style: SequenceStyle.Block));
+                foreach (var child in array)
+                    EmitJsonNode(emitter, child);
+                emitter.Emit(new SequenceEnd());
+                return;
+
+            case JsonValue jsonValue:
+                EmitJsonScalar(emitter, jsonValue);
+                return;
+
+            default:
+                EmitScalar(emitter, node.ToJsonString());
+                return;
+        }
+    }
+
+    private static void EmitJsonScalar(IEmitter emitter, JsonValue jsonValue)
+    {
+        switch (jsonValue.GetValueKind())
+        {
+            case JsonValueKind.String:
+                EmitScalar(emitter, jsonValue.GetValue<string>());
+                return;
+            case JsonValueKind.True:
+                EmitScalar(emitter, "true");
+                return;
+            case JsonValueKind.False:
+                EmitScalar(emitter, "false");
+                return;
+            case JsonValueKind.Null:
+                EmitNull(emitter);
+                return;
+            case JsonValueKind.Number:
+                EmitScalar(emitter, jsonValue.ToJsonString());
+                return;
+            default:
+                EmitScalar(emitter, jsonValue.ToJsonString());
+                return;
+        }
+    }
+
+    private static void EmitMapping(IEmitter emitter, IDictionary<string, object?> dict)
+    {
+        emitter.Emit(new MappingStart(anchor: null, tag: null, isImplicit: true, style: MappingStyle.Block));
+        foreach (var (key, value) in dict)
+        {
+            EmitScalar(emitter, key);
+            EmitNode(emitter, value);
+        }
+        emitter.Emit(new MappingEnd());
+    }
+
+    private static void EmitMapping(IEmitter emitter, IDictionary dict)
+    {
+        emitter.Emit(new MappingStart(anchor: null, tag: null, isImplicit: true, style: MappingStyle.Block));
+        foreach (DictionaryEntry entry in dict)
+        {
+            var keyString = entry.Key as string ?? entry.Key.ToString() ?? "";
+            EmitScalar(emitter, keyString);
+            EmitNode(emitter, entry.Value);
+        }
+        emitter.Emit(new MappingEnd());
+    }
+
+    private static void EmitSequence(IEmitter emitter, IEnumerable enumerable)
+    {
+        var items = new List<object?>();
+        foreach (var item in enumerable)
+            items.Add(item);
+
+        if (items.Count == 0)
+        {
+            emitter.Emit(new SequenceStart(anchor: null, tag: null, isImplicit: true, style: SequenceStyle.Flow));
+            emitter.Emit(new SequenceEnd());
+            return;
+        }
+
+        emitter.Emit(new SequenceStart(anchor: null, tag: null, isImplicit: true, style: SequenceStyle.Block));
+        foreach (var item in items)
+            EmitNode(emitter, item);
+        emitter.Emit(new SequenceEnd());
+    }
+
+    private static void EmitScalar(IEmitter emitter, string value)
+    {
+        emitter.Emit(new Scalar(
+            anchor: null,
+            tag: null,
+            value: value,
+            style: ScalarStyle.Any,
+            isPlainImplicit: true,
+            isQuotedImplicit: true));
+    }
+
+    private static readonly TagName NullTag = new("tag:yaml.org,2002:null");
+
+    private static void EmitNull(IEmitter emitter)
+    {
+        // Reproduce YamlDotNet's high-level "Channel: " output for a null
+        // mapping value. Setting the null tag tells the emitter the empty
+        // value is genuinely null, so it won't promote it to a quoted
+        // empty string ('').
+        emitter.Emit(new Scalar(
+            anchor: default,
+            tag: NullTag,
+            value: string.Empty,
+            style: ScalarStyle.Plain,
+            isPlainImplicit: true,
+            isQuotedImplicit: true));
+    }
+}

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Cmdlets/ModuleFiles/Devolutions.Pinget.Client.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'Devolutions.Pinget.Client.psm1'
-    ModuleVersion = '0.6.0'
+    ModuleVersion = '0.7.0'
     CompatiblePSEditions = @('Desktop', 'Core')
     GUID = 'c6d1b5f2-5ccd-4771-9480-25caad7c58bd'
     Author = 'Devolutions'

--- a/dotnet/src/Devolutions.Pinget.PowerShell.Engine/PowerShellEngineVersion.cs
+++ b/dotnet/src/Devolutions.Pinget.PowerShell.Engine/PowerShellEngineVersion.cs
@@ -2,5 +2,5 @@ namespace Devolutions.Pinget.PowerShell.Engine;
 
 public static class PowerShellEngineVersion
 {
-    public const string Current = "0.6.0";
+    public const string Current = "0.7.0";
 }

--- a/nuget/Devolutions.Pinget.Cli.DotNet/Devolutions.Pinget.Cli.DotNet.csproj
+++ b/nuget/Devolutions.Pinget.Cli.DotNet/Devolutions.Pinget.Cli.DotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Pack">
 
   <PropertyGroup>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Company>Devolutions Inc.</Company>
     <Authors>Devolutions</Authors>
     <PackageId>Devolutions.Pinget.Cli.DotNet</PackageId>

--- a/nuget/Devolutions.Pinget.Cli.Rust/Devolutions.Pinget.Cli.Rust.csproj
+++ b/nuget/Devolutions.Pinget.Cli.Rust/Devolutions.Pinget.Cli.Rust.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Pack">
 
   <PropertyGroup>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Company>Devolutions Inc.</Company>
     <Authors>Devolutions</Authors>
     <PackageId>Devolutions.Pinget.Cli.Rust</PackageId>

--- a/rust/crates/pinget-cli/Cargo.toml
+++ b/rust/crates/pinget-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinget-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 
 [lints]
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
-pinget-core = { version = "0.6.0", path = "../pinget-core" }
+pinget-core = { version = "0.7.0", path = "../pinget-core" }
 chrono = "0.4.44"
 dirs = "6.0"
 jsonschema = "0.30"

--- a/rust/crates/pinget-cli/src/main.rs
+++ b/rust/crates/pinget-cli/src/main.rs
@@ -700,17 +700,11 @@ fn run() -> Result<()> {
                             }
                         }
                     }
-                    println!(
-                        "{} of {} package(s) upgraded.",
-                        success_count,
-                        upgradeable.len()
-                    );
+                    println!("{} of {} package(s) upgraded.", success_count, upgradeable.len());
                     if failure_count > 0 {
                         // Surface the failure to the caller (UniGetUI, scripts, etc.)
                         // so they don't treat a partial failure as success.
-                        bail!(
-                            "{failure_count} package(s) failed to upgrade during upgrade --all"
-                        );
+                        bail!("{failure_count} package(s) failed to upgrade during upgrade --all");
                     }
                 }
             }

--- a/rust/crates/pinget-cli/src/main.rs
+++ b/rust/crates/pinget-cli/src/main.rs
@@ -634,6 +634,8 @@ fn run() -> Result<()> {
                     println!("No applicable upgrade found.");
                 } else {
                     let pins = repository.list_pins(None)?;
+                    let mut success_count = 0usize;
+                    let mut failure_count = 0usize;
                     for m in &upgradeable {
                         println!(
                             "Upgrading {} from {} to {} ...",
@@ -648,6 +650,7 @@ fn run() -> Result<()> {
                                 "  Package is blocked by pin {}; remove the pin before upgrading.",
                                 pin.version
                             );
+                            failure_count += 1;
                             continue;
                         }
                         let query = PackageQuery {
@@ -682,19 +685,33 @@ fn run() -> Result<()> {
                         }) {
                             Ok(r) if r.success => {
                                 println!("  Successfully upgraded {}", m.id);
+                                success_count += 1;
                             }
                             Ok(r) => {
                                 write_stderr_line(format_args!(
                                     "  Failed to upgrade {} (exit code: {})",
                                     m.id, r.exit_code
                                 ));
+                                failure_count += 1;
                             }
                             Err(e) => {
                                 write_stderr_line(format_args!("  Error upgrading {}: {e}", m.id));
+                                failure_count += 1;
                             }
                         }
                     }
-                    println!("{} package(s) upgraded.", upgradeable.len());
+                    println!(
+                        "{} of {} package(s) upgraded.",
+                        success_count,
+                        upgradeable.len()
+                    );
+                    if failure_count > 0 {
+                        // Surface the failure to the caller (UniGetUI, scripts, etc.)
+                        // so they don't treat a partial failure as success.
+                        bail!(
+                            "{failure_count} package(s) failed to upgrade during upgrade --all"
+                        );
+                    }
                 }
             }
         }

--- a/rust/crates/pinget-com/Cargo.toml
+++ b/rust/crates/pinget-com/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinget-com"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "Windows-only native COM bridge for Pinget backed by pinget-core."
 license = "MIT"

--- a/rust/crates/pinget-core/Cargo.toml
+++ b/rust/crates/pinget-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinget-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "Pure Rust Pinget core library that works directly with source caches, REST endpoints, and installed package state without COM."
 license = "MIT"

--- a/rust/crates/pinget-core/Cargo.toml
+++ b/rust/crates/pinget-core/Cargo.toml
@@ -30,4 +30,4 @@ zip = "8.5.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55.0"
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_Packaging_Appx", "Win32_System_SystemInformation", "Win32_System_Threading"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_Packaging_Appx", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -7774,13 +7774,21 @@ fn install_portable(
     let install_directory_created = !dir_existed || prev_dir_created;
 
     let installer_type = installer.installer_type.as_deref().unwrap_or("");
-    if installer_type.eq_ignore_ascii_case("zip") {
+    let portable_target_full_path: PathBuf = if installer_type.eq_ignore_ascii_case("zip") {
         let file = fs::File::open(installer_path)
             .with_context(|| format!("failed to open installer zip: {}", installer_path.display()))?;
         let mut archive = ZipArchive::new(file).context("failed to read installer zip")?;
         archive
             .extract(&target_dir)
             .with_context(|| format!("failed to extract zip into: {}", target_dir.display()))?;
+        // For nested-portable zips the binary lives at the RelativeFilePath the
+        // manifest declares. We record the first one as PortableTargetFullPath so
+        // winget's portable uninstall workflow can identify which file to remove.
+        installer
+            .nested_installer_files
+            .first()
+            .map(|file| target_dir.join(&file.relative_file_path))
+            .unwrap_or_else(|| target_dir.clone())
     } else {
         // Standalone portable: copy the downloaded file into target_dir using
         // its original filename. winget would optionally rename to the
@@ -7788,13 +7796,16 @@ fn install_portable(
         let basename = installer_path
             .file_name()
             .ok_or_else(|| anyhow!("portable installer has no filename"))?;
-        fs::copy(installer_path, target_dir.join(basename))
+        let copied = target_dir.join(basename);
+        fs::copy(installer_path, &copied)
             .with_context(|| format!("failed to copy portable binary into: {}", target_dir.display()))?;
-    }
+        copied
+    };
 
     write_portable_arp_entry(
         &subkey_name,
         &target_dir,
+        &portable_target_full_path,
         install_directory_created,
         &source_identifier,
         manifest,
@@ -7908,6 +7919,7 @@ fn clean_directory_contents(dir: &Path) -> Result<()> {
 fn write_portable_arp_entry(
     subkey_name: &str,
     install_location: &Path,
+    portable_target_full_path: &Path,
     install_directory_created: bool,
     source_identifier: &str,
     manifest: &Manifest,
@@ -7925,6 +7937,10 @@ fn write_portable_arp_entry(
     subkey.set_value("WinGetSourceIdentifier", &source_identifier.to_owned())?;
     subkey.set_value("WinGetInstallerType", &"portable".to_owned())?;
     subkey.set_value("InstallLocation", &install_location_str)?;
+    subkey.set_value(
+        "PortableTargetFullPath",
+        &portable_target_full_path.to_string_lossy().to_string(),
+    )?;
     subkey.set_value(
         "InstallDirectoryCreated",
         &(if install_directory_created { 1u32 } else { 0u32 }),

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -8315,16 +8315,6 @@ fn write_portable_arp_entry(entry: &PortableArpEntry<'_>) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(windows))]
-fn install_portable(
-    _installer_path: &Path,
-    _request: &InstallRequest,
-    _manifest: &Manifest,
-    _installer: &Installer,
-) -> Result<i32> {
-    bail!("Portable installs are only supported on Windows")
-}
-
 #[cfg(test)]
 mod tests {
     use std::io::Write;

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -7770,12 +7770,11 @@ fn try_remove_portable_symlinks(
         let _ = fs::remove_file(path);
     }
 
-    // Defensive sweep: walk Links\ and remove shims whose stored target path
-    // was inside install_location. By this point install_location is already
-    // deleted, so we compare the symlink's stored target string (which the
-    // filesystem retains even after the target itself is gone).
+    // Defensive sweep: walk Links\ and remove shims whose stored target was
+    // inside (or equal to) install_location. By this point install_location is
+    // already deleted, so we compare the symlink's stored target string (which
+    // the filesystem retains even after the target itself is gone).
     let Some(install_dir) = install_location else { return };
-    let install_prefix = install_dir.to_string_lossy().to_ascii_lowercase();
 
     let Some(local) = dirs::data_local_dir() else { return };
     let links_root = local.join("Microsoft").join("WinGet").join("Links");
@@ -7783,11 +7782,34 @@ fn try_remove_portable_symlinks(
     for entry in entries.flatten() {
         let path = entry.path();
         let Ok(target) = fs::read_link(&path) else { continue };
-        let target_str = target.to_string_lossy().to_ascii_lowercase();
-        if target_str.starts_with(&install_prefix) {
+        if path_starts_with_case_insensitive(&target, install_dir) {
             let _ = fs::remove_file(&path);
         }
     }
+}
+
+/// Case-insensitive, component-aware path-prefix check for Windows. A raw
+/// `str::starts_with` on the path strings would let `C:\Foo` falsely match
+/// `C:\Foobar`; iterating path components avoids that. Used by the Links\
+/// sweep so an uninstall of one portable can't accidentally delete shims that
+/// belong to a different portable whose install dir happens to share a
+/// string-prefix.
+#[cfg(windows)]
+fn path_starts_with_case_insensitive(child: &Path, parent: &Path) -> bool {
+    let lower_components = |p: &Path| -> Vec<String> {
+        p.components()
+            .map(|c| c.as_os_str().to_string_lossy().to_ascii_lowercase())
+            .collect()
+    };
+    let parent_components = lower_components(parent);
+    let child_components = lower_components(child);
+    if parent_components.is_empty() || parent_components.len() > child_components.len() {
+        return false;
+    }
+    parent_components
+        .iter()
+        .zip(child_components.iter())
+        .all(|(a, b)| a == b)
 }
 
 /// Best-effort removal of the HKCU/HKLM ARP subkey backing a portable entry.
@@ -8169,17 +8191,39 @@ fn resolve_portable_install_location(
     existing: &Option<ExistingPortableEntry>,
     subkey_name: &str,
 ) -> PathBuf {
-    if let Some(custom) = request.install_location.as_deref()
+    resolve_portable_install_location_pure(
+        request.install_location.as_deref(),
+        existing
+            .as_ref()
+            .and_then(|e| e.install_location.as_deref())
+            .and_then(Path::to_str),
+        subkey_name,
+        &default_user_portable_root(),
+    )
+}
+
+/// Pure resolution rule for the portable install directory. Priority:
+/// `request_location` (CLI override) → `existing_location` (so upgrades
+/// preserve a winget-installed location) → default user portable root joined
+/// with the package's ARP subkey name.
+#[cfg(windows)]
+fn resolve_portable_install_location_pure(
+    request_location: Option<&str>,
+    existing_location: Option<&str>,
+    subkey_name: &str,
+    default_user_portable_root: &Path,
+) -> PathBuf {
+    if let Some(custom) = request_location
         && !custom.is_empty()
     {
         return PathBuf::from(custom);
     }
-    if let Some(entry) = existing
-        && let Some(loc) = entry.install_location.clone()
+    if let Some(loc) = existing_location
+        && !loc.is_empty()
     {
-        return loc;
+        return PathBuf::from(loc);
     }
-    default_user_portable_root().join(subkey_name)
+    default_user_portable_root.join(subkey_name)
 }
 
 #[cfg(windows)]
@@ -8296,6 +8340,253 @@ mod tests {
             "pinget-rs-tests-{label}-{}",
             Utc::now().timestamp_nanos_opt().unwrap_or_default()
         ))
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn path_prefix_check_rejects_string_prefix_collisions() {
+        // Regression: a naive str::starts_with would falsely consider
+        // C:\Foobar a child of C:\Foo and let the Links\ sweep delete unrelated
+        // symlinks. The component-aware check must reject these.
+        assert!(!path_starts_with_case_insensitive(
+            Path::new(r"C:\Foobar\bin.exe"),
+            Path::new(r"C:\Foo"),
+        ));
+        assert!(!path_starts_with_case_insensitive(
+            Path::new(r"C:\Foo\bin.exe.bak"),
+            Path::new(r"C:\Foo\bin.exe"),
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn path_prefix_check_accepts_real_children_and_self() {
+        // Dir install: the symlink target lives inside the install dir.
+        assert!(path_starts_with_case_insensitive(
+            Path::new(r"C:\Foo\sub\bin.exe"),
+            Path::new(r"C:\Foo"),
+        ));
+        // File install: the symlink points at the same file we removed.
+        assert!(path_starts_with_case_insensitive(
+            Path::new(r"C:\Foo\bin.exe"),
+            Path::new(r"C:\Foo\bin.exe"),
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn path_prefix_check_is_case_insensitive() {
+        // Windows paths are case-insensitive — winget and pinget may write
+        // them with different casing.
+        assert!(path_starts_with_case_insensitive(
+            Path::new(r"c:\users\test\appdata\local\microsoft\winget\packages\foo\bin.exe"),
+            Path::new(r"C:\Users\test\AppData\Local\Microsoft\WinGet\Packages\Foo"),
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn portable_source_identifier_maps_winget_catalog_to_canonical_id() {
+        let query = PackageQuery {
+            source: Some("winget".to_owned()),
+            ..PackageQuery::default()
+        };
+        assert_eq!(
+            portable_source_identifier(&query),
+            "Microsoft.Winget.Source_8wekyb3d8bbwe"
+        );
+        // Case-insensitive — manifests/catalog may report differently.
+        let query = PackageQuery {
+            source: Some("WINGET".to_owned()),
+            ..PackageQuery::default()
+        };
+        assert_eq!(
+            portable_source_identifier(&query),
+            "Microsoft.Winget.Source_8wekyb3d8bbwe"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn portable_source_identifier_passes_through_custom_sources() {
+        let query = PackageQuery {
+            source: Some("internal-feed".to_owned()),
+            ..PackageQuery::default()
+        };
+        assert_eq!(portable_source_identifier(&query), "internal-feed");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn portable_source_identifier_defaults_for_missing_or_empty_source() {
+        let query = PackageQuery {
+            source: None,
+            ..PackageQuery::default()
+        };
+        assert_eq!(
+            portable_source_identifier(&query),
+            "Microsoft.Winget.Source_8wekyb3d8bbwe"
+        );
+        let query = PackageQuery {
+            source: Some(String::new()),
+            ..PackageQuery::default()
+        };
+        assert_eq!(
+            portable_source_identifier(&query),
+            "Microsoft.Winget.Source_8wekyb3d8bbwe"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn portable_subkey_name_matches_winget_format() {
+        assert_eq!(
+            portable_subkey_name("BurntSushi.ripgrep.MSVC", "Microsoft.Winget.Source_8wekyb3d8bbwe"),
+            "BurntSushi.ripgrep.MSVC_Microsoft.Winget.Source_8wekyb3d8bbwe"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn determine_portable_alias_prefers_nested_installer_alias() {
+        let installer = Installer {
+            nested_installer_files: vec![NestedInstallerFile {
+                relative_file_path: "ripgrep/rg.exe".to_owned(),
+                portable_command_alias: Some("rg".to_owned()),
+            }],
+            commands: vec!["other-name".to_owned()],
+            ..Installer::default()
+        };
+        assert_eq!(determine_portable_alias(&installer).as_deref(), Some("rg"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn determine_portable_alias_falls_back_to_commands() {
+        let installer = Installer {
+            // No nested files at all (standalone portable case).
+            commands: vec!["nuget".to_owned()],
+            ..Installer::default()
+        };
+        assert_eq!(determine_portable_alias(&installer).as_deref(), Some("nuget"));
+
+        // Nested files exist but none declare PortableCommandAlias.
+        let installer = Installer {
+            nested_installer_files: vec![NestedInstallerFile {
+                relative_file_path: "subdir/bin.exe".to_owned(),
+                portable_command_alias: None,
+            }],
+            commands: vec!["bin".to_owned()],
+            ..Installer::default()
+        };
+        assert_eq!(determine_portable_alias(&installer).as_deref(), Some("bin"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn determine_portable_alias_returns_none_without_alias_or_commands() {
+        let installer = Installer::default();
+        assert!(determine_portable_alias(&installer).is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_portable_install_location_prefers_request_override() {
+        let result = resolve_portable_install_location_pure(
+            Some(r"D:\Tools\rg"),
+            Some(r"C:\Software\rg-test"),
+            "Sub_Source",
+            Path::new(r"C:\default"),
+        );
+        assert_eq!(result, PathBuf::from(r"D:\Tools\rg"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_portable_install_location_preserves_existing_location_for_upgrades() {
+        // The #4823 scenario: pinget upgrade with no explicit --location must
+        // resolve to the install_location the prior install recorded, not the
+        // default portable root.
+        let result = resolve_portable_install_location_pure(
+            None,
+            Some(r"C:\Software\rg-test"),
+            "Sub_Source",
+            Path::new(r"C:\default"),
+        );
+        assert_eq!(result, PathBuf::from(r"C:\Software\rg-test"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_portable_install_location_falls_back_to_default_root() {
+        let result = resolve_portable_install_location_pure(
+            None,
+            None,
+            "Sub_Source",
+            Path::new(r"C:\default"),
+        );
+        assert_eq!(result, PathBuf::from(r"C:\default\Sub_Source"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_portable_install_location_treats_empty_strings_as_unset() {
+        // Defensive: PackageQuery / registry reads can yield "" instead of
+        // None for missing values.
+        let result = resolve_portable_install_location_pure(
+            Some(""),
+            Some(""),
+            "Sub_Source",
+            Path::new(r"C:\default"),
+        );
+        assert_eq!(result, PathBuf::from(r"C:\default\Sub_Source"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn clean_directory_contents_removes_files_and_subdirs_but_keeps_root() {
+        let root = std::env::temp_dir().join(format!(
+            "pinget-clean-test-{}",
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        fs::create_dir_all(&root).expect("create temp dir");
+        fs::write(root.join("a.txt"), b"hello").expect("write a.txt");
+        fs::create_dir_all(root.join("nested")).expect("create nested dir");
+        fs::write(root.join("nested").join("b.txt"), b"world").expect("write nested/b.txt");
+
+        clean_directory_contents(&root).expect("clean root contents");
+
+        assert!(root.is_dir(), "root dir itself must survive");
+        assert_eq!(
+            fs::read_dir(&root).expect("read root").count(),
+            0,
+            "root must be empty after clean"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn clean_directory_contents_is_a_noop_on_nonexistent_dir() {
+        let bogus = std::env::temp_dir().join(format!(
+            "pinget-clean-test-bogus-{}",
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        assert!(!bogus.exists());
+        clean_directory_contents(&bogus).expect("clean nonexistent dir");
+        // Should not have created the dir.
+        assert!(!bogus.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn path_prefix_check_handles_mixed_separators() {
+        // NestedInstallerFiles RelativeFilePath uses '/' in manifests, so the
+        // path we joined can end up mixed-separator on Windows.
+        assert!(path_starts_with_case_insensitive(
+            Path::new(r"C:\Foo\sub/bin.exe"),
+            Path::new(r"C:\Foo"),
+        ));
     }
 
     #[test]

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -7725,9 +7725,10 @@ fn uninstall_portable(installed: &ListMatch, request: &UninstallRequest) -> Resu
 }
 
 /// Reads `PortableSymlinkFullPath` from the ARP subkey backing `installed`
-/// when present. winget writes this when it created a `Links\<alias>.exe`
-/// shim for a portable; pinget's own install_portable doesn't currently
-/// create shims, so for pinget-installed entries this returns None.
+/// when present. This value is recorded for portable installs that created a
+/// `Links\<alias>.exe` symlink, including pinget-installed entries when
+/// `install_portable` created that link. Entries without a created/recorded
+/// portable symlink return `None`.
 #[cfg(windows)]
 fn read_portable_symlink_full_path(installed: &ListMatch) -> Option<String> {
     const ARP_PREFIX: &str = r"ARP\";

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -3675,7 +3675,17 @@ fn collect_uninstall_view(
             }
         }
         let installer_category =
-            if local_id.starts_with("ARP\\") && read_reg_dword(&subkey, "WindowsInstaller") == Some(1) {
+            if read_reg_string(&subkey, "WinGetInstallerType")
+                .as_deref()
+                .is_some_and(|value| value.eq_ignore_ascii_case("portable"))
+            {
+                // Honor the WinGet ARP signal so uninstall flows through
+                // uninstall_portable (clean dir + registry removal) instead of
+                // delegating the WinGet portable UninstallString to a winget
+                // subprocess that only fully cleans up entries winget itself
+                // installed.
+                Some("portable".to_owned())
+            } else if local_id.starts_with("ARP\\") && read_reg_dword(&subkey, "WindowsInstaller") == Some(1) {
                 Some("msi".to_owned())
             } else if key_name.starts_with("MSIX\\") {
                 Some("msix".to_owned())
@@ -7670,6 +7680,7 @@ fn try_run_msi_uninstall(
 fn uninstall_portable(installed: &ListMatch, request: &UninstallRequest) -> Result<i32> {
     let Some(location) = installed.install_location.as_deref() else {
         if request.force {
+            try_remove_portable_registry_entry(installed);
             return Ok(0);
         }
         bail!(
@@ -7683,19 +7694,76 @@ fn uninstall_portable(installed: &ListMatch, request: &UninstallRequest) -> Resu
     }
 
     let path = Path::new(location);
-    if path.is_dir() {
+    let removed = if path.is_dir() {
         fs::remove_dir_all(path)?;
-        return Ok(0);
-    }
-    if path.is_file() {
+        true
+    } else if path.is_file() {
         fs::remove_file(path)?;
-        return Ok(0);
-    }
-    if request.force {
+        true
+    } else {
+        false
+    };
+
+    if removed || request.force {
+        // Once the files are gone (or the user forced past missing files), drop
+        // the ARP entry too so the package no longer shows in installed lists.
+        try_remove_portable_registry_entry(installed);
         return Ok(0);
     }
 
     bail!("Portable package location not found: {location}")
+}
+
+/// Best-effort removal of the HKCU/HKLM ARP subkey backing a portable entry.
+/// We match on local_id (`ARP\<scope>\<arch>\<subkey>`) when present so we
+/// delete the exact key the list view surfaced; otherwise we walk the standard
+/// Uninstall path and match on WinGetPackageIdentifier. Failures are logged via
+/// the returned warning chain in callers — we never bubble a registry-cleanup
+/// failure as a hard error because the file deletion already succeeded.
+#[cfg(windows)]
+fn try_remove_portable_registry_entry(installed: &ListMatch) {
+    // Collect (is_hkcu, subkey_path) pairs so we can re-open hives at delete
+    // time instead of holding clones of RegKey (which doesn't implement Clone).
+    let candidates: Vec<(bool, String)> = if let Some(rest) = installed.local_id.strip_prefix(r"ARP\") {
+        // local_id format is `ARP\<scope>\<arch>\<subkey>` — pick the right hive/path.
+        let mut parts = rest.splitn(3, '\\');
+        let scope = parts.next().unwrap_or("");
+        let _arch = parts.next();
+        let subkey_name = parts.next().unwrap_or("");
+        if subkey_name.is_empty() {
+            return;
+        }
+        let is_hkcu = scope.eq_ignore_ascii_case("User");
+        vec![(is_hkcu, format!(r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}"))]
+    } else {
+        // Fall back to scanning by WinGetPackageIdentifier.
+        let mut found = Vec::new();
+        for (is_hkcu, hive) in [
+            (true, RegKey::predef(HKEY_CURRENT_USER)),
+            (false, RegKey::predef(HKEY_LOCAL_MACHINE)),
+        ] {
+            let Ok(uninstall) = hive.open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Uninstall") else { continue };
+            for name in uninstall.enum_keys().flatten() {
+                let Ok(subkey) = uninstall.open_subkey(&name) else { continue };
+                if read_reg_string(&subkey, "WinGetPackageIdentifier").as_deref() == Some(installed.id.as_str()) {
+                    found.push((
+                        is_hkcu,
+                        format!(r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{name}"),
+                    ));
+                }
+            }
+        }
+        found
+    };
+
+    for (is_hkcu, path) in candidates {
+        let hive = if is_hkcu {
+            RegKey::predef(HKEY_CURRENT_USER)
+        } else {
+            RegKey::predef(HKEY_LOCAL_MACHINE)
+        };
+        let _ = hive.delete_subkey_all(&path);
+    }
 }
 
 #[cfg(windows)]

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -3675,24 +3675,23 @@ fn collect_uninstall_view(
                 }
             }
         }
-        let installer_category =
-            if read_reg_string(&subkey, "WinGetInstallerType")
-                .as_deref()
-                .is_some_and(|value| value.eq_ignore_ascii_case("portable"))
-            {
-                // Honor the WinGet ARP signal so uninstall flows through
-                // uninstall_portable (clean dir + registry removal) instead of
-                // delegating the WinGet portable UninstallString to a winget
-                // subprocess that only fully cleans up entries winget itself
-                // installed.
-                Some("portable".to_owned())
-            } else if local_id.starts_with("ARP\\") && read_reg_dword(&subkey, "WindowsInstaller") == Some(1) {
-                Some("msi".to_owned())
-            } else if key_name.starts_with("MSIX\\") {
-                Some("msix".to_owned())
-            } else {
-                Some("exe".to_owned())
-            };
+        let installer_category = if read_reg_string(&subkey, "WinGetInstallerType")
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case("portable"))
+        {
+            // Honor the WinGet ARP signal so uninstall flows through
+            // uninstall_portable (clean dir + registry removal) instead of
+            // delegating the WinGet portable UninstallString to a winget
+            // subprocess that only fully cleans up entries winget itself
+            // installed.
+            Some("portable".to_owned())
+        } else if local_id.starts_with("ARP\\") && read_reg_dword(&subkey, "WindowsInstaller") == Some(1) {
+            Some("msi".to_owned())
+        } else if key_name.starts_with("MSIX\\") {
+            Some("msix".to_owned())
+        } else {
+            Some("exe".to_owned())
+        };
 
         let dedupe_key = format!(
             "{}|{}|{}|{}",
@@ -5816,8 +5815,7 @@ fn parse_rest_manifest(bytes: &[u8], package_id: &str, version: &str, channel: &
                     minimum_os_version: json_string(item, "MinimumOSVersion")
                         .or_else(|| top_minimum_os_version.clone()),
                     architecture: json_string(item, "Architecture"),
-                    installer_type: json_string(item, "InstallerType")
-                        .or_else(|| top_installer_type.clone()),
+                    installer_type: json_string(item, "InstallerType").or_else(|| top_installer_type.clone()),
                     nested_installer_type: json_string(item, "NestedInstallerType")
                         .or_else(|| top_nested_installer_type.clone()),
                     nested_installer_files: {
@@ -7832,7 +7830,10 @@ fn try_remove_portable_registry_entry(installed: &ListMatch) {
             return;
         }
         let is_hkcu = scope.eq_ignore_ascii_case("User");
-        vec![(is_hkcu, format!(r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}"))]
+        vec![(
+            is_hkcu,
+            format!(r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}"),
+        )]
     } else {
         // Fall back to scanning by WinGetPackageIdentifier.
         let mut found = Vec::new();
@@ -7840,9 +7841,13 @@ fn try_remove_portable_registry_entry(installed: &ListMatch) {
             (true, RegKey::predef(HKEY_CURRENT_USER)),
             (false, RegKey::predef(HKEY_LOCAL_MACHINE)),
         ] {
-            let Ok(uninstall) = hive.open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Uninstall") else { continue };
+            let Ok(uninstall) = hive.open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Uninstall") else {
+                continue;
+            };
             for name in uninstall.enum_keys().flatten() {
-                let Ok(subkey) = uninstall.open_subkey(&name) else { continue };
+                let Ok(subkey) = uninstall.open_subkey(&name) else {
+                    continue;
+                };
                 if read_reg_string(&subkey, "WinGetPackageIdentifier").as_deref() == Some(installed.id.as_str()) {
                     found.push((
                         is_hkcu,
@@ -7931,9 +7936,8 @@ fn install_portable(
         })?;
     }
 
-    fs::create_dir_all(&target_dir).with_context(|| {
-        format!("failed to create portable install directory: {}", target_dir.display())
-    })?;
+    fs::create_dir_all(&target_dir)
+        .with_context(|| format!("failed to create portable install directory: {}", target_dir.display()))?;
     // The "we created it" flag stays sticky across upgrades — if a previous
     // install marked it created, it still counts as created by us even when
     // the dir already existed this round.
@@ -7974,9 +7978,7 @@ fn install_portable(
     // we still leave the package installed at install_location.
     let alias = determine_portable_alias(installer);
     let symlink_full_path = match alias.as_deref() {
-        Some(alias) if !alias.is_empty() => {
-            try_create_portable_symlink(&portable_target_full_path, alias)
-        }
+        Some(alias) if !alias.is_empty() => try_create_portable_symlink(&portable_target_full_path, alias),
         _ => None,
     };
 
@@ -8107,6 +8109,7 @@ fn try_add_links_dir_to_user_path() -> bool {
 fn broadcast_environment_change() {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
+
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         HWND_BROADCAST, SMTO_ABORTIFHUNG, SendMessageTimeoutW, WM_SETTINGCHANGE,
     };
@@ -8139,9 +8142,7 @@ fn broadcast_environment_change() {
 #[cfg(windows)]
 fn portable_source_identifier(query: &PackageQuery) -> String {
     match query.source.as_deref() {
-        Some(name) if name.eq_ignore_ascii_case("winget") => {
-            "Microsoft.Winget.Source_8wekyb3d8bbwe".to_owned()
-        }
+        Some(name) if name.eq_ignore_ascii_case("winget") => "Microsoft.Winget.Source_8wekyb3d8bbwe".to_owned(),
         Some(name) if !name.is_empty() => name.to_owned(),
         _ => "Microsoft.Winget.Source_8wekyb3d8bbwe".to_owned(),
     }
@@ -8166,7 +8167,9 @@ fn read_existing_portable_entry(package_id: &str) -> Option<ExistingPortableEntr
         .open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Uninstall")
         .ok()?;
     for name in uninstall.enum_keys().flatten() {
-        let Ok(subkey) = uninstall.open_subkey(&name) else { continue };
+        let Ok(subkey) = uninstall.open_subkey(&name) else {
+            continue;
+        };
         if read_reg_string(&subkey, "WinGetPackageIdentifier").as_deref() != Some(package_id) {
             continue;
         }
@@ -8277,10 +8280,7 @@ fn write_portable_arp_entry(entry: &PortableArpEntry<'_>) -> Result<()> {
         &entry.portable_target_full_path.to_string_lossy().to_string(),
     )?;
     if let Some(symlink_path) = entry.portable_symlink_full_path {
-        subkey.set_value(
-            "PortableSymlinkFullPath",
-            &symlink_path.to_string_lossy().to_string(),
-        )?;
+        subkey.set_value("PortableSymlinkFullPath", &symlink_path.to_string_lossy().to_string())?;
     }
     subkey.set_value(
         "InstallDirectoryAddedToPath",
@@ -8519,12 +8519,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn resolve_portable_install_location_falls_back_to_default_root() {
-        let result = resolve_portable_install_location_pure(
-            None,
-            None,
-            "Sub_Source",
-            Path::new(r"C:\default"),
-        );
+        let result = resolve_portable_install_location_pure(None, None, "Sub_Source", Path::new(r"C:\default"));
         assert_eq!(result, PathBuf::from(r"C:\default\Sub_Source"));
     }
 
@@ -8533,12 +8528,7 @@ mod tests {
     fn resolve_portable_install_location_treats_empty_strings_as_unset() {
         // Defensive: PackageQuery / registry reads can yield "" instead of
         // None for missing values.
-        let result = resolve_portable_install_location_pure(
-            Some(""),
-            Some(""),
-            "Sub_Source",
-            Path::new(r"C:\default"),
-        );
+        let result = resolve_portable_install_location_pure(Some(""), Some(""), "Sub_Source", Path::new(r"C:\default"));
         assert_eq!(result, PathBuf::from(r"C:\default\Sub_Source"));
     }
 

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -332,7 +332,8 @@ pub struct NestedInstallerFile {
     /// Path to the executable within the extracted archive.
     pub relative_file_path: String,
     /// Optional alias winget exposes for portable invocation. Pinget records it
-    /// for parity but doesn't yet create symlinks / PATH entries.
+    /// for parity and uses it during portable installation to create a
+    /// `Links\\<alias>.exe` symlink; `Links\\` may also be added to the user PATH.
     pub portable_command_alias: Option<String>,
 }
 

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -305,10 +305,12 @@ pub struct PackageAgreement {
     pub url: Option<String>,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Installer {
     pub architecture: Option<String>,
     pub installer_type: Option<String>,
+    pub nested_installer_type: Option<String>,
+    pub nested_installer_files: Vec<NestedInstallerFile>,
     pub url: Option<String>,
     pub sha256: Option<String>,
     pub product_code: Option<String>,
@@ -323,6 +325,15 @@ pub struct Installer {
     pub commands: Vec<String>,
     pub package_dependencies: Vec<String>,
     pub require_explicit_upgrade: bool,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct NestedInstallerFile {
+    /// Path to the executable within the extracted archive.
+    pub relative_file_path: String,
+    /// Optional alias winget exposes for portable invocation. Pinget records it
+    /// for parity but doesn't yet create symlinks / PATH entries.
+    pub portable_command_alias: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
@@ -5772,6 +5783,9 @@ fn parse_rest_manifest(bytes: &[u8], package_id: &str, version: &str, channel: &
     let installer_switch_defaults = json_installer_switches(selected);
     let top_platforms = json_string_list(selected, "Platform");
     let top_minimum_os_version = json_string(selected, "MinimumOSVersion");
+    let top_installer_type = json_string(selected, "InstallerType");
+    let top_nested_installer_type = json_string(selected, "NestedInstallerType");
+    let top_nested_installer_files = json_nested_installer_files(selected);
 
     let installers = selected
         .get("Installers")
@@ -5791,7 +5805,18 @@ fn parse_rest_manifest(bytes: &[u8], package_id: &str, version: &str, channel: &
                     minimum_os_version: json_string(item, "MinimumOSVersion")
                         .or_else(|| top_minimum_os_version.clone()),
                     architecture: json_string(item, "Architecture"),
-                    installer_type: json_string(item, "InstallerType"),
+                    installer_type: json_string(item, "InstallerType")
+                        .or_else(|| top_installer_type.clone()),
+                    nested_installer_type: json_string(item, "NestedInstallerType")
+                        .or_else(|| top_nested_installer_type.clone()),
+                    nested_installer_files: {
+                        let files = json_nested_installer_files(item);
+                        if files.is_empty() {
+                            top_nested_installer_files.clone()
+                        } else {
+                            files
+                        }
+                    },
                     url: json_string(item, "InstallerUrl"),
                     sha256: json_string(item, "InstallerSha256"),
                     product_code: json_string(item, "ProductCode"),
@@ -6173,6 +6198,8 @@ fn installer_defaults(root: &YamlMapping) -> YamlMapping {
     let keys = [
         "Architecture",
         "InstallerType",
+        "NestedInstallerType",
+        "NestedInstallerFiles",
         "InstallerUrl",
         "InstallerSha256",
         "ProductCode",
@@ -6198,6 +6225,8 @@ fn installer_from_yaml(root: &YamlMapping, switches: InstallerSwitches) -> Insta
     Installer {
         architecture: yaml_string(root, "Architecture"),
         installer_type: yaml_string(root, "InstallerType"),
+        nested_installer_type: yaml_string(root, "NestedInstallerType"),
+        nested_installer_files: yaml_nested_installer_files(root),
         url: yaml_string(root, "InstallerUrl"),
         sha256: yaml_string(root, "InstallerSha256"),
         product_code: yaml_string(root, "ProductCode"),
@@ -6342,6 +6371,25 @@ fn yaml_package_dependencies(root: &YamlMapping) -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn yaml_nested_installer_files(root: &YamlMapping) -> Vec<NestedInstallerFile> {
+    root.get(YamlValue::from("NestedInstallerFiles"))
+        .and_then(YamlValue::as_sequence)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(YamlValue::as_mapping)
+                .filter_map(|item| {
+                    let relative = yaml_string(item, "RelativeFilePath")?;
+                    Some(NestedInstallerFile {
+                        relative_file_path: relative,
+                        portable_command_alias: yaml_string(item, "PortableCommandAlias"),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn json_string(value: &JsonValue, key: &str) -> Option<String> {
     value.get(key).and_then(JsonValue::as_str).map(str::to_owned)
 }
@@ -6400,6 +6448,25 @@ fn json_package_dependencies(value: &JsonValue) -> Vec<String> {
             items
                 .iter()
                 .filter_map(|item| json_string(item, "PackageIdentifier"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn json_nested_installer_files(value: &JsonValue) -> Vec<NestedInstallerFile> {
+    value
+        .get("NestedInstallerFiles")
+        .and_then(JsonValue::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let relative = json_string(item, "RelativeFilePath")?;
+                    Some(NestedInstallerFile {
+                        relative_file_path: relative,
+                        portable_command_alias: json_string(item, "PortableCommandAlias"),
+                    })
+                })
                 .collect()
         })
         .unwrap_or_default()
@@ -7040,6 +7107,18 @@ fn dispatch_installer(
             Ok(status.code().unwrap_or(-1))
         }
         "zip" => {
+            // A `zip` at the top-level installer position is treated as portable when
+            // `NestedInstallerType=portable` is specified — that's the shape every
+            // portable in the winget catalog uses (e.g. BurntSushi.ripgrep.MSVC).
+            // Anything else still falls through to the historical extract-to-Programs
+            // behavior, which isn't really correct but at least doesn't regress.
+            if installer
+                .nested_installer_type
+                .as_deref()
+                .is_some_and(|value| value.eq_ignore_ascii_case("portable"))
+            {
+                return install_portable(installer_path, request, manifest, installer);
+            }
             let target = dirs::data_local_dir()
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join("Programs");
@@ -7049,6 +7128,7 @@ fn dispatch_installer(
             archive.extract(&target)?;
             Ok(0)
         }
+        "portable" => install_portable(installer_path, request, manifest, installer),
         // exe, inno, nullsoft, burn, etc.
         _ => {
             let mut cmd = Command::new(installer_path);
@@ -7628,6 +7708,262 @@ fn uninstall_package(_installed: &ListMatch, _request: &UninstallRequest) -> Res
     bail!("Uninstalling packages is only supported on Windows")
 }
 
+/// Installs (or upgrades) a portable WinGet package.
+///
+/// Handles both `InstallerType: portable` (single binary download) and
+/// `InstallerType: zip` with `NestedInstallerType: portable` (zip containing
+/// the binary at a relative path), which is the shape every portable in the
+/// community winget catalog uses today.
+///
+/// Behavior matches winget's portable workflow closely enough that the resulting
+/// HKCU ARP entry is recognized by `winget list` and by pinget's own list view:
+/// - Resolves the target install directory in this priority order:
+///   1. `request.install_location` if provided (passed for upgrades)
+///   2. Existing `InstallLocation` from the registry ARP entry (so upgrades
+///      with no explicit location still preserve the user's custom path)
+///   3. WinGet's default user portable root, `%LOCALAPPDATA%\Microsoft\WinGet
+///      \Packages\<PackageId>_<SourceId>`
+/// - If an existing pinget-owned install lives in that directory
+///   (`InstallDirectoryCreated=1`), cleans its contents before extracting the
+///   new version so leftover files from older versions don't pile up.
+/// - Extracts the zip (or copies the standalone binary), then writes the ARP
+///   registry entry that `winget list` and pinget's `collect_uninstall_view`
+///   both read from.
+#[cfg(windows)]
+fn install_portable(
+    installer_path: &Path,
+    request: &InstallRequest,
+    manifest: &Manifest,
+    installer: &Installer,
+) -> Result<i32> {
+    let source_identifier = portable_source_identifier(&request.query);
+    let existing_entry = read_existing_portable_entry(&manifest.id);
+    // Reuse the existing subkey name on upgrade so we don't orphan the prior
+    // entry by writing to a different one.
+    let subkey_name = existing_entry
+        .as_ref()
+        .map(|entry| entry.subkey_name.clone())
+        .unwrap_or_else(|| portable_subkey_name(&manifest.id, &source_identifier));
+
+    let target_dir = resolve_portable_install_location(request, &existing_entry, &subkey_name);
+
+    // If we created this directory on a previous install, wipe it clean so the
+    // new version doesn't co-exist with leftovers from the previous one. We do
+    // not touch a directory we don't own (InstallDirectoryCreated != 1), to
+    // avoid stomping user data.
+    let prev_dir_created = existing_entry
+        .as_ref()
+        .and_then(|entry| entry.install_directory_created)
+        == Some(1);
+    let dir_existed = target_dir.is_dir();
+    if prev_dir_created && dir_existed {
+        clean_directory_contents(&target_dir).with_context(|| {
+            format!(
+                "failed to clean existing portable install directory: {}",
+                target_dir.display()
+            )
+        })?;
+    }
+
+    fs::create_dir_all(&target_dir).with_context(|| {
+        format!("failed to create portable install directory: {}", target_dir.display())
+    })?;
+    // The "we created it" flag stays sticky across upgrades — if a previous
+    // install marked it created, it still counts as created by us even when
+    // the dir already existed this round.
+    let install_directory_created = !dir_existed || prev_dir_created;
+
+    let installer_type = installer.installer_type.as_deref().unwrap_or("");
+    if installer_type.eq_ignore_ascii_case("zip") {
+        let file = fs::File::open(installer_path)
+            .with_context(|| format!("failed to open installer zip: {}", installer_path.display()))?;
+        let mut archive = ZipArchive::new(file).context("failed to read installer zip")?;
+        archive
+            .extract(&target_dir)
+            .with_context(|| format!("failed to extract zip into: {}", target_dir.display()))?;
+    } else {
+        // Standalone portable: copy the downloaded file into target_dir using
+        // its original filename. winget would optionally rename to the
+        // PortableCommandAlias; pinget keeps the original name for now.
+        let basename = installer_path
+            .file_name()
+            .ok_or_else(|| anyhow!("portable installer has no filename"))?;
+        fs::copy(installer_path, target_dir.join(basename))
+            .with_context(|| format!("failed to copy portable binary into: {}", target_dir.display()))?;
+    }
+
+    write_portable_arp_entry(
+        &subkey_name,
+        &target_dir,
+        install_directory_created,
+        &source_identifier,
+        manifest,
+    )?;
+
+    Ok(0)
+}
+
+/// Source identifier embedded in the ARP subkey name. We mirror winget for
+/// the community repo so winget's UninstallString can resolve the subkey and
+/// `winget list` still finds the package; everything else uses the source
+/// name verbatim.
+#[cfg(windows)]
+fn portable_source_identifier(query: &PackageQuery) -> String {
+    match query.source.as_deref() {
+        Some(name) if name.eq_ignore_ascii_case("winget") => {
+            "Microsoft.Winget.Source_8wekyb3d8bbwe".to_owned()
+        }
+        Some(name) if !name.is_empty() => name.to_owned(),
+        _ => "Microsoft.Winget.Source_8wekyb3d8bbwe".to_owned(),
+    }
+}
+
+#[cfg(windows)]
+fn portable_subkey_name(package_id: &str, source_identifier: &str) -> String {
+    format!("{package_id}_{source_identifier}")
+}
+
+#[cfg(windows)]
+struct ExistingPortableEntry {
+    install_location: Option<PathBuf>,
+    install_directory_created: Option<u32>,
+    subkey_name: String,
+}
+
+#[cfg(windows)]
+fn read_existing_portable_entry(package_id: &str) -> Option<ExistingPortableEntry> {
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let uninstall = hkcu
+        .open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Uninstall")
+        .ok()?;
+    for name in uninstall.enum_keys().flatten() {
+        let Ok(subkey) = uninstall.open_subkey(&name) else { continue };
+        if read_reg_string(&subkey, "WinGetPackageIdentifier").as_deref() != Some(package_id) {
+            continue;
+        }
+        if !read_reg_string(&subkey, "WinGetInstallerType")
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case("portable"))
+        {
+            continue;
+        }
+        return Some(ExistingPortableEntry {
+            install_location: read_reg_string(&subkey, "InstallLocation").map(PathBuf::from),
+            install_directory_created: read_reg_dword(&subkey, "InstallDirectoryCreated"),
+            subkey_name: name,
+        });
+    }
+    None
+}
+
+#[cfg(windows)]
+fn resolve_portable_install_location(
+    request: &InstallRequest,
+    existing: &Option<ExistingPortableEntry>,
+    subkey_name: &str,
+) -> PathBuf {
+    if let Some(custom) = request.install_location.as_deref()
+        && !custom.is_empty()
+    {
+        return PathBuf::from(custom);
+    }
+    if let Some(entry) = existing
+        && let Some(loc) = entry.install_location.clone()
+    {
+        return loc;
+    }
+    default_user_portable_root().join(subkey_name)
+}
+
+#[cfg(windows)]
+fn default_user_portable_root() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Microsoft")
+        .join("WinGet")
+        .join("Packages")
+}
+
+#[cfg(windows)]
+fn clean_directory_contents(dir: &Path) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            fs::remove_dir_all(&path)?;
+        } else {
+            fs::remove_file(&path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Writes the HKCU ARP entry winget would normally write for a portable
+/// install. Only the subset that winget's portable list view and pinget's
+/// `collect_uninstall_view` actually read.
+#[cfg(windows)]
+fn write_portable_arp_entry(
+    subkey_name: &str,
+    install_location: &Path,
+    install_directory_created: bool,
+    source_identifier: &str,
+    manifest: &Manifest,
+) -> Result<()> {
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let uninstall_path = format!(
+        r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}"
+    );
+    let (subkey, _) = hkcu
+        .create_subkey(&uninstall_path)
+        .context("failed to create portable ARP registry subkey")?;
+
+    let install_location_str = install_location.to_string_lossy().to_string();
+    subkey.set_value("WinGetPackageIdentifier", &manifest.id)?;
+    subkey.set_value("WinGetSourceIdentifier", &source_identifier.to_owned())?;
+    subkey.set_value("WinGetInstallerType", &"portable".to_owned())?;
+    subkey.set_value("InstallLocation", &install_location_str)?;
+    subkey.set_value(
+        "InstallDirectoryCreated",
+        &(if install_directory_created { 1u32 } else { 0u32 }),
+    )?;
+    subkey.set_value(
+        "DisplayName",
+        &if manifest.name.is_empty() {
+            manifest.id.clone()
+        } else {
+            manifest.name.clone()
+        },
+    )?;
+    subkey.set_value("DisplayVersion", &manifest.version)?;
+    if let Some(publisher) = manifest.publisher.as_ref() {
+        subkey.set_value("Publisher", publisher)?;
+    }
+    subkey.set_value(
+        "UninstallString",
+        &format!("winget uninstall --product-code {subkey_name}"),
+    )?;
+    let today = Utc::now().format("%Y%m%d").to_string();
+    subkey.set_value("InstallDate", &today)?;
+    if let Some(url) = manifest.package_url.as_ref() {
+        subkey.set_value("URLInfoAbout", url)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn install_portable(
+    _installer_path: &Path,
+    _request: &InstallRequest,
+    _manifest: &Manifest,
+    _installer: &Installer,
+) -> Result<i32> {
+    bail!("Portable installs are only supported on Windows")
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;
@@ -8091,6 +8427,8 @@ mod tests {
                     commands: vec!["testpkg".to_owned()],
                     package_dependencies: vec!["Microsoft.UI.Xaml.2.8".to_owned()],
                     require_explicit_upgrade: false,
+                    nested_installer_type: None,
+                    nested_installer_files: Vec::new(),
                 }],
                 require_explicit_upgrade: false,
             },
@@ -8114,6 +8452,8 @@ mod tests {
                 commands: vec!["testpkg".to_owned()],
                 package_dependencies: vec!["Microsoft.UI.Xaml.2.8".to_owned()],
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             }),
             cached_files: vec![PathBuf::from(r"C:\temp\cache\Test.Package.yaml")],
             warnings: vec!["cache warmed".to_owned()],
@@ -8382,6 +8722,8 @@ Installers:
                 commands: Vec::new(),
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             })
             .collect();
         Manifest {
@@ -8874,6 +9216,8 @@ Installers:
             commands: Vec::new(),
             package_dependencies: Vec::new(),
             require_explicit_upgrade: false,
+            nested_installer_type: None,
+            nested_installer_files: Vec::new(),
         };
         let manifest = Manifest {
             id: "Test.Package".to_owned(),
@@ -8959,6 +9303,8 @@ Installers:
             commands: Vec::new(),
             package_dependencies: Vec::new(),
             require_explicit_upgrade: false,
+            nested_installer_type: None,
+            nested_installer_files: Vec::new(),
         };
         let manifest = Manifest {
             id: "Test.Package".to_owned(),
@@ -9047,6 +9393,8 @@ Installers:
             commands: Vec::new(),
             package_dependencies: Vec::new(),
             require_explicit_upgrade: false,
+            nested_installer_type: None,
+            nested_installer_files: Vec::new(),
         };
         let manifest = Manifest {
             id: "ShareX.ShareX".to_owned(),
@@ -9233,6 +9581,8 @@ Installers:
                 commands: Vec::new(),
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             },
             Installer {
                 architecture: Some("x64".to_owned()),
@@ -9251,6 +9601,8 @@ Installers:
                 commands: vec!["demo".to_owned()],
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             },
         ];
         let query = PackageQuery {
@@ -9286,6 +9638,8 @@ Installers:
                 commands: Vec::new(),
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             },
             Installer {
                 architecture: Some("x64".to_owned()),
@@ -9304,6 +9658,8 @@ Installers:
                 commands: Vec::new(),
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             },
         ];
 
@@ -9331,6 +9687,8 @@ Installers:
                 commands: Vec::new(),
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             },
             Installer {
                 architecture: Some("x64".to_owned()),
@@ -9349,6 +9707,8 @@ Installers:
                 commands: Vec::new(),
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             },
         ];
         let query = PackageQuery {
@@ -9381,6 +9741,8 @@ Installers:
                 commands: Vec::new(),
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             },
             Installer {
                 architecture: Some("x64".to_owned()),
@@ -9399,6 +9761,8 @@ Installers:
                 commands: Vec::new(),
                 package_dependencies: Vec::new(),
                 require_explicit_upgrade: false,
+                nested_installer_type: None,
+                nested_installer_files: Vec::new(),
             },
         ];
         let query = PackageQuery {

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -7678,8 +7678,16 @@ fn try_run_msi_uninstall(
 
 #[cfg(windows)]
 fn uninstall_portable(installed: &ListMatch, request: &UninstallRequest) -> Result<i32> {
+    // Read PortableSymlinkFullPath from the ARP entry *before* we touch the
+    // registry, so we can remove winget-created shims in Links\ if any. Without
+    // this, a portable that winget originally installed (with a
+    // PortableCommandAlias set in its manifest) would leave a dangling symlink
+    // in %LOCALAPPDATA%\Microsoft\WinGet\Links\ once pinget uninstalls it.
+    let known_symlink = read_portable_symlink_full_path(installed);
+
     let Some(location) = installed.install_location.as_deref() else {
         if request.force {
+            try_remove_portable_symlinks(installed, &known_symlink, None);
             try_remove_portable_registry_entry(installed);
             return Ok(0);
         }
@@ -7706,12 +7714,78 @@ fn uninstall_portable(installed: &ListMatch, request: &UninstallRequest) -> Resu
 
     if removed || request.force {
         // Once the files are gone (or the user forced past missing files), drop
-        // the ARP entry too so the package no longer shows in installed lists.
+        // the symlink shim and ARP entry too so the package fully disappears.
+        try_remove_portable_symlinks(installed, &known_symlink, Some(path));
         try_remove_portable_registry_entry(installed);
         return Ok(0);
     }
 
     bail!("Portable package location not found: {location}")
+}
+
+/// Reads `PortableSymlinkFullPath` from the ARP subkey backing `installed`
+/// when present. winget writes this when it created a `Links\<alias>.exe`
+/// shim for a portable; pinget's own install_portable doesn't currently
+/// create shims, so for pinget-installed entries this returns None.
+#[cfg(windows)]
+fn read_portable_symlink_full_path(installed: &ListMatch) -> Option<String> {
+    const ARP_PREFIX: &str = r"ARP\";
+    if let Some(rest) = installed.local_id.strip_prefix(ARP_PREFIX) {
+        let mut parts = rest.splitn(3, '\\');
+        let scope = parts.next().unwrap_or("");
+        let _arch = parts.next();
+        let subkey_name = parts.next().unwrap_or("");
+        if subkey_name.is_empty() {
+            return None;
+        }
+        let hive = if scope.eq_ignore_ascii_case("User") {
+            RegKey::predef(HKEY_CURRENT_USER)
+        } else {
+            RegKey::predef(HKEY_LOCAL_MACHINE)
+        };
+        let subkey = hive
+            .open_subkey(format!(
+                r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}"
+            ))
+            .ok()?;
+        return read_reg_string(&subkey, "PortableSymlinkFullPath");
+    }
+    None
+}
+
+/// Removes the symlink shims winget would have created for this portable.
+/// Tries (1) the exact path from `PortableSymlinkFullPath` if known, and
+/// (2) any symlink in `%LOCALAPPDATA%\Microsoft\WinGet\Links\` whose target
+/// resolves under `install_location` (defensive sweep for shims winget made
+/// but didn't surface in the registry). Best-effort: failures are swallowed.
+#[cfg(windows)]
+fn try_remove_portable_symlinks(
+    _installed: &ListMatch,
+    known_symlink: &Option<String>,
+    install_location: Option<&Path>,
+) {
+    if let Some(path) = known_symlink.as_deref() {
+        let _ = fs::remove_file(path);
+    }
+
+    // Defensive sweep: walk Links\ and remove shims whose stored target path
+    // was inside install_location. By this point install_location is already
+    // deleted, so we compare the symlink's stored target string (which the
+    // filesystem retains even after the target itself is gone).
+    let Some(install_dir) = install_location else { return };
+    let install_prefix = install_dir.to_string_lossy().to_ascii_lowercase();
+
+    let Some(local) = dirs::data_local_dir() else { return };
+    let links_root = local.join("Microsoft").join("WinGet").join("Links");
+    let Ok(entries) = fs::read_dir(&links_root) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(target) = fs::read_link(&path) else { continue };
+        let target_str = target.to_string_lossy().to_ascii_lowercase();
+        if target_str.starts_with(&install_prefix) {
+            let _ = fs::remove_file(&path);
+        }
+    }
 }
 
 /// Best-effort removal of the HKCU/HKLM ARP subkey backing a portable entry.
@@ -7870,16 +7944,168 @@ fn install_portable(
         copied
     };
 
-    write_portable_arp_entry(
-        &subkey_name,
-        &target_dir,
-        &portable_target_full_path,
+    // Create the Links\<alias>.exe shim so users can invoke the portable from
+    // any shell, matching winget's portable workflow. Failures are non-fatal —
+    // when the user lacks SeCreateSymbolicLink (no Developer Mode, not admin)
+    // we still leave the package installed at install_location.
+    let alias = determine_portable_alias(installer);
+    let symlink_full_path = match alias.as_deref() {
+        Some(alias) if !alias.is_empty() => {
+            try_create_portable_symlink(&portable_target_full_path, alias)
+        }
+        _ => None,
+    };
+
+    // Ensure %LOCALAPPDATA%\Microsoft\WinGet\Links is on user PATH so the
+    // symlink we just created is resolvable from new shells. Tracks whether we
+    // added it this round so uninstall can decide whether to take it back out.
+    let added_to_path = if symlink_full_path.is_some() {
+        try_add_links_dir_to_user_path()
+    } else {
+        false
+    };
+
+    write_portable_arp_entry(&PortableArpEntry {
+        subkey_name: &subkey_name,
+        install_location: &target_dir,
+        portable_target_full_path: &portable_target_full_path,
+        portable_symlink_full_path: symlink_full_path.as_deref(),
         install_directory_created,
-        &source_identifier,
+        added_to_path,
+        source_identifier: &source_identifier,
         manifest,
-    )?;
+    })?;
 
     Ok(0)
+}
+
+#[cfg(windows)]
+struct PortableArpEntry<'a> {
+    subkey_name: &'a str,
+    install_location: &'a Path,
+    portable_target_full_path: &'a Path,
+    portable_symlink_full_path: Option<&'a Path>,
+    install_directory_created: bool,
+    added_to_path: bool,
+    source_identifier: &'a str,
+    manifest: &'a Manifest,
+}
+
+/// Picks the portable command alias from the manifest. Mirrors winget's
+/// resolution: nested-installer files first (used by zip+portable manifests),
+/// then the top-level `Commands` field (used by standalone portable manifests).
+/// Returns None when the manifest doesn't declare a command — the package
+/// still installs, just without a Links\ shim.
+#[cfg(windows)]
+fn determine_portable_alias(installer: &Installer) -> Option<String> {
+    installer
+        .nested_installer_files
+        .iter()
+        .find_map(|file| file.portable_command_alias.clone())
+        .or_else(|| installer.commands.first().cloned())
+}
+
+#[cfg(windows)]
+fn winget_links_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Microsoft")
+        .join("WinGet")
+        .join("Links")
+}
+
+/// Creates (or replaces) `Links\<alias>.exe` as a file symlink pointing at the
+/// portable's binary. Returns the link path on success. Returns None and logs
+/// a warning if the user can't create symlinks (no Developer Mode, not admin)
+/// so the install can still complete without the shim.
+#[cfg(windows)]
+fn try_create_portable_symlink(target: &Path, alias: &str) -> Option<PathBuf> {
+    use std::os::windows::fs::symlink_file;
+    let links_dir = winget_links_dir();
+    if fs::create_dir_all(&links_dir).is_err() {
+        return None;
+    }
+    let link_path = links_dir.join(format!("{alias}.exe"));
+
+    // Replace any prior link/file at the path so upgrades repoint to the new
+    // binary instead of leaving a stale symlink behind.
+    if link_path.symlink_metadata().is_ok() {
+        let _ = fs::remove_file(&link_path);
+    }
+
+    // Symlink creation fails with ERROR_PRIVILEGE_NOT_HELD (1314) when the
+    // process lacks SeCreateSymbolicLink (no Developer Mode, not admin). Treat
+    // that — and any other I/O failure — as non-fatal: the package files are
+    // already in place, just without a Links\ shim.
+    symlink_file(target, &link_path).ok().map(|()| link_path)
+}
+
+/// Adds `Links\` to the user's HKCU\Environment\Path if not already present,
+/// then broadcasts WM_SETTINGCHANGE so explorer-spawned shells pick up the
+/// new PATH without a logoff. Returns true if we actually appended PATH this
+/// call — callers should write `InstallDirectoryAddedToPath` accordingly so a
+/// follow-up uninstall doesn't take PATH back out for other portables.
+#[cfg(windows)]
+fn try_add_links_dir_to_user_path() -> bool {
+    let links_dir = winget_links_dir();
+    let links_str = links_dir.to_string_lossy().to_string();
+    let normalized_links = links_str.to_ascii_lowercase();
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let Ok(env_key) = hkcu.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE) else {
+        return false;
+    };
+    let existing: String = env_key.get_value("Path").unwrap_or_default();
+    let already_present = existing
+        .split(';')
+        .any(|component| component.trim().to_ascii_lowercase() == normalized_links);
+    if already_present {
+        return false;
+    }
+
+    let new_path = if existing.is_empty() {
+        links_str
+    } else if existing.ends_with(';') {
+        format!("{existing}{links_str}")
+    } else {
+        format!("{existing};{links_str}")
+    };
+
+    if env_key.set_value("Path", &new_path).is_err() {
+        return false;
+    }
+
+    broadcast_environment_change();
+    true
+}
+
+#[cfg(windows)]
+fn broadcast_environment_change() {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        HWND_BROADCAST, SMTO_ABORTIFHUNG, SendMessageTimeoutW, WM_SETTINGCHANGE,
+    };
+
+    let param: Vec<u16> = OsStr::new("Environment")
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // SAFETY: SendMessageTimeoutW only reads `param` for the duration of the
+    // call (it copies the string before returning), and `result` is a stack
+    // local we provide. No aliasing or lifetime issues.
+    unsafe {
+        let mut result: usize = 0;
+        SendMessageTimeoutW(
+            HWND_BROADCAST,
+            WM_SETTINGCHANGE,
+            0usize,
+            param.as_ptr() as isize,
+            SMTO_ABORTIFHUNG,
+            5000,
+            &mut result,
+        );
+    }
 }
 
 /// Source identifier embedded in the ARP subkey name. We mirror winget for
@@ -7984,34 +8210,39 @@ fn clean_directory_contents(dir: &Path) -> Result<()> {
 /// install. Only the subset that winget's portable list view and pinget's
 /// `collect_uninstall_view` actually read.
 #[cfg(windows)]
-fn write_portable_arp_entry(
-    subkey_name: &str,
-    install_location: &Path,
-    portable_target_full_path: &Path,
-    install_directory_created: bool,
-    source_identifier: &str,
-    manifest: &Manifest,
-) -> Result<()> {
+fn write_portable_arp_entry(entry: &PortableArpEntry<'_>) -> Result<()> {
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     let uninstall_path = format!(
-        r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}"
+        r"Software\Microsoft\Windows\CurrentVersion\Uninstall\{}",
+        entry.subkey_name
     );
     let (subkey, _) = hkcu
         .create_subkey(&uninstall_path)
         .context("failed to create portable ARP registry subkey")?;
 
-    let install_location_str = install_location.to_string_lossy().to_string();
+    let manifest = entry.manifest;
+    let install_location_str = entry.install_location.to_string_lossy().to_string();
     subkey.set_value("WinGetPackageIdentifier", &manifest.id)?;
-    subkey.set_value("WinGetSourceIdentifier", &source_identifier.to_owned())?;
+    subkey.set_value("WinGetSourceIdentifier", &entry.source_identifier.to_owned())?;
     subkey.set_value("WinGetInstallerType", &"portable".to_owned())?;
     subkey.set_value("InstallLocation", &install_location_str)?;
     subkey.set_value(
         "PortableTargetFullPath",
-        &portable_target_full_path.to_string_lossy().to_string(),
+        &entry.portable_target_full_path.to_string_lossy().to_string(),
+    )?;
+    if let Some(symlink_path) = entry.portable_symlink_full_path {
+        subkey.set_value(
+            "PortableSymlinkFullPath",
+            &symlink_path.to_string_lossy().to_string(),
+        )?;
+    }
+    subkey.set_value(
+        "InstallDirectoryAddedToPath",
+        &(if entry.added_to_path { 1u32 } else { 0u32 }),
     )?;
     subkey.set_value(
         "InstallDirectoryCreated",
-        &(if install_directory_created { 1u32 } else { 0u32 }),
+        &(if entry.install_directory_created { 1u32 } else { 0u32 }),
     )?;
     subkey.set_value(
         "DisplayName",
@@ -8027,7 +8258,7 @@ fn write_portable_arp_entry(
     }
     subkey.set_value(
         "UninstallString",
-        &format!("winget uninstall --product-code {subkey_name}"),
+        &format!("winget uninstall --product-code {}", entry.subkey_name),
     )?;
     let today = Utc::now().format("%Y%m%d").to_string();
     subkey.set_value("InstallDate", &today)?;

--- a/scripts/Build-CliNativeNuGetPackages.ps1
+++ b/scripts/Build-CliNativeNuGetPackages.ps1
@@ -443,7 +443,23 @@ if ($buildRust) {
         New-Item -Path $stageDir -ItemType Directory -Force | Out-Null
 
         if (-not $NoBuild) {
-            Invoke-NativeCommand -FilePath rustup -ArgumentList @('target', 'add', $target['CargoTarget'])
+            # Only call `rustup target add` when the target isn't already
+            # installed. CI typically pre-installs the target in a separate
+            # workflow step, and a redundant `target add` here would hit
+            # static.rust-lang.org again — that download has flaked in the past
+            # (e.g. osx-x64 on macos-14), failing the build for a network
+            # transient. `rustup target list --installed` is local-only.
+            $installedTargets = & rustup target list --installed 2>$null
+            if ($LASTEXITCODE -ne 0) {
+                throw "rustup target list --installed failed with exit code $LASTEXITCODE"
+            }
+            $cargoTarget = $target['CargoTarget']
+            $alreadyInstalled = $installedTargets | Where-Object { $_.Trim() -eq $cargoTarget }
+            if (-not $alreadyInstalled) {
+                Invoke-NativeCommand -FilePath rustup -ArgumentList @('target', 'add', $cargoTarget)
+            } else {
+                Write-Host ">> rustup target '$cargoTarget' already installed; skipping target add"
+            }
             $previousRustFlags = $env:RUSTFLAGS
             try {
                 if ($target['CargoTarget'] -like '*-windows-msvc') {


### PR DESCRIPTION
This pull request introduces improvements to package upgrade error handling and extends support for portable installers with nested files. The most significant changes include surfacing partial upgrade failures to the caller in both the .NET and Rust CLIs, and adding support for tracking and serializing nested portable installer files throughout the codebase. Additionally, the ARP package collection logic now better honors WinGet's portable installer signals.

**Upgrade error handling improvements:**

- Both the .NET (`Program.cs`) and Rust (`main.rs`) CLIs now track and report the number of failed upgrades during `upgrade --all`, surfacing partial failures to the caller by setting a non-zero exit code or returning an error. This ensures that scripts and UI tools do not treat partial failures as overall success.

**Portable installer and nested file support:**

- Added a new `NestedInstallerFile` record to represent files within a portable installer archive, and updated the `Installer` and `SerializableInstaller` models to include a list of these files. Serialization, deserialization, and structured output logic were updated accordingly.
- Updated repository and REST source parsing to correctly read and merge `NestedInstallerFiles` from manifests and JSON data, ensuring that installer definitions accurately reflect nested portable files. 

**Windows ARP and installer detection:**

- Improved ARP package collection to honor the `WinGetInstallerType` registry value, ensuring that uninstall flows for portable apps installed by WinGet use the correct cleanup path.

**Test updates:**

- Replaced and updated tests in `CoreTests.cs` to validate the new portable zip installer detection logic.

**Other:**

- Minor dependency update: enabled the `Win32_UI_WindowsAndMessaging` feature for the `windows-sys` crate on Windows.