### PR TITLE
Fix stale preindexed package details

### DIFF
--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
@@ -2987,6 +2987,64 @@ public class RepositoryEmbeddingTests
     }
 
     [Fact]
+    public void Show_PreindexedDownloadedManifestHashMismatch_ThrowsInsteadOfCachingStaleBytes()
+    {
+        const string packageId = "Test.HashMismatchPackage";
+        const string version = "1.0.0";
+        var catalog = PreindexedCatalogFixture.Create(packageId, version);
+        var manifestPath = $"manifests/{packageId}/{version}.yaml";
+        var staleManifestBytes = Encoding.UTF8.GetBytes($$"""
+            PackageIdentifier: {{packageId}}
+            PackageVersion: 0.9.0
+            DefaultLocale: en-US
+            ManifestType: singleton
+            ManifestVersion: 1.10.0
+            PackageLocale: en-US
+            PackageName: {{packageId}}
+            Publisher: Example
+            License: MIT
+            ShortDescription: stale package
+            Installers:
+              - Architecture: x64
+                InstallerType: exe
+                InstallerUrl: https://example.test/{{packageId}}/0.9.0.exe
+                InstallerSha256: {{new string('B', 64)}}
+            """);
+        var files = catalog.Files.Select(file =>
+            string.Equals(file.Key, manifestPath, StringComparison.OrdinalIgnoreCase)
+                ? new KeyValuePair<string, byte[]>(file.Key, staleManifestBytes)
+                : file);
+
+        using var server = new TestPreindexedSourceServer(catalog.MsixBytes, files);
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                PreIndexedSourceAutoUpdateInterval = null,
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.PreIndexed));
+            WritePreindexedIndex(appRoot, repo, "test", catalog.IndexBytes);
+
+            var ex = Assert.Throws<SourceSearchException>(() => repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+                Version = version,
+            }));
+
+            Assert.Contains("Hash mismatch", ex.Message);
+            Assert.Contains(manifestPath, ex.Message);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
     public void Show_MultipleSourcesExposeStructuredMatches()
     {
         using var firstServer = new TestRestSourceServer();

--- a/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
+++ b/dotnet/src/Devolutions.Pinget.Core.Tests/CoreTests.cs
@@ -1,4 +1,7 @@
 using System.Diagnostics;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using System.Net;
 using System.Net.Sockets;
@@ -25,6 +28,85 @@ public class VersionCompareTests
     {
         var result = RestSource.CompareVersionStrings(a, b);
         Assert.Equal(expected, Math.Sign(result));
+    }
+
+    public class VersionSelectionTests
+    {
+        [Fact]
+        public void SelectV2Version_WithoutRequestedVersion_ReturnsLatest()
+        {
+            var selected = Repository.SelectV2VersionForTesting(
+            [
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.0.0" },
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.2.0" },
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.1.0" },
+            ], requestedVersion: null);
+
+            Assert.Equal("1.2.0", selected.Version);
+        }
+
+        [Fact]
+        public void SelectV2Version_WithExistingRequestedVersion_ReturnsRequestedVersion()
+        {
+            var selected = Repository.SelectV2VersionForTesting(
+            [
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.2.0" },
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.1.0" },
+            ], "1.1.0");
+
+            Assert.Equal("1.1.0", selected.Version);
+        }
+
+        [Fact]
+        public void SelectV2Version_WithMissingRequestedVersion_Throws()
+        {
+            var ex = Assert.Throws<MissingPackageVersionException>(() => Repository.SelectV2VersionForTesting(
+            [
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.2.0" },
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.1.0" },
+            ], "9.9.9"));
+
+            Assert.Contains("9.9.9", ex.Message);
+        }
+
+        [Fact]
+        public void SelectV2Version_WithRequestedChannel_ThrowsInsteadOfIgnoringChannel()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => Repository.SelectV2VersionForTesting(
+            [
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.2.0" },
+                new PreIndexedSource.V2VersionDataEntry { Version = "1.1.0" },
+            ], "1.2.0", "beta"));
+
+            Assert.Contains("beta", ex.Message);
+            Assert.Contains("channel metadata", ex.Message);
+        }
+
+        [Fact]
+        public void SelectV1Version_WithRequestedChannelMismatch_Throws()
+        {
+            var ex = Assert.Throws<MissingPackageVersionException>(() => Repository.SelectV1VersionForTesting(
+            [
+                new PreIndexedSource.V1VersionRow { Version = "1.2.0", Channel = "stable" },
+                new PreIndexedSource.V1VersionRow { Version = "1.1.0", Channel = "beta" },
+            ], "1.2.0", "beta"));
+
+            Assert.Equal("1.2.0", ex.RequestedVersion);
+            Assert.Equal("beta", ex.RequestedChannel);
+        }
+
+        [Fact]
+        public void SelectRestVersion_WithRequestedChannelMismatch_Throws()
+        {
+            var ex = Assert.Throws<MissingPackageVersionException>(() => Repository.SelectRestVersionForTesting(
+            [
+                new VersionKey { Version = "1.2.0", Channel = "stable" },
+                new VersionKey { Version = "1.1.0", Channel = "beta" },
+            ], "1.2.0", "beta"));
+
+            Assert.Equal("1.2.0", ex.RequestedVersion);
+            Assert.Equal("beta", ex.RequestedChannel);
+        }
     }
 }
 
@@ -2600,6 +2682,311 @@ public class RepositoryEmbeddingTests
     }
 
     [Fact]
+    public void Show_RestExplicitMissingVersion_ThrowsInsteadOfReturningLatest()
+    {
+        using var server = new TestRestSourceServer();
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions { AppRoot = appRoot });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.Rest));
+
+            var ex = Assert.Throws<SourceSearchException>(() => repo.Show(new PackageQuery
+            {
+                Id = TesslPackageId,
+                Exact = true,
+                Source = "test",
+                Version = "9.9.9",
+            }));
+
+            var missing = Assert.IsType<MissingPackageVersionException>(ex.InnerException);
+            Assert.Equal("9.9.9", missing.RequestedVersion);
+            Assert.Contains("9.9.9", ex.Message);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_PreindexedExplicitMissingVersion_RefreshesOnceAndReturnsRequestedVersion()
+    {
+        const string packageId = "Test.RefreshPackage";
+        var initialCatalog = PreindexedCatalogFixture.Create(packageId, "1.0.0");
+        var refreshedCatalog = PreindexedCatalogFixture.Create(packageId, "1.1.0", "1.0.0");
+
+        using var server = new TestPreindexedSourceServer(refreshedCatalog.MsixBytes, initialCatalog.Files.Concat(refreshedCatalog.Files));
+        var diagnostics = new List<RepositoryWarning>();
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                Diagnostics = diagnostics.Add,
+                PreIndexedSourceAutoUpdateInterval = null,
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.PreIndexed));
+            WritePreindexedIndex(appRoot, repo, "test", initialCatalog.IndexBytes);
+
+            var result = repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+                Version = "1.1.0",
+            });
+
+            Assert.Equal("1.1.0", result.PackageVersion);
+            Assert.Equal(1, server.SourceUpdateRequests);
+            Assert.Contains(diagnostics, warning =>
+                warning.Operation == "manifest-refresh" &&
+                warning.Message.Contains(packageId, StringComparison.Ordinal) &&
+                warning.Message.Contains("1.1.0", StringComparison.Ordinal));
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_PreindexedExplicitMissingVersion_RefreshesAfterCachedAutoRefreshFailure()
+    {
+        const string packageId = "Test.RecoveredRefreshPackage";
+        var initialCatalog = PreindexedCatalogFixture.Create(packageId, "1.0.0");
+        var refreshedCatalog = PreindexedCatalogFixture.Create(packageId, "1.1.0", "1.0.0");
+
+        using var server = new TestPreindexedSourceServer(msixBytes: null, initialCatalog.Files.Concat(refreshedCatalog.Files));
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                PreIndexedSourceAutoUpdateInterval = TimeSpan.FromDays(1),
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.PreIndexed));
+            var indexPath = WritePreindexedIndex(appRoot, repo, "test", initialCatalog.IndexBytes);
+            File.SetLastWriteTimeUtc(indexPath, DateTime.UtcNow.AddDays(-1));
+
+            var localResult = repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+            });
+
+            Assert.Equal("1.0.0", localResult.PackageVersion);
+            Assert.Equal(1, server.SourceUpdateRequests);
+
+            server.SetMsixBytes(refreshedCatalog.MsixBytes);
+
+            var refreshedResult = repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+                Version = "1.1.0",
+            });
+
+            Assert.Equal("1.1.0", refreshedResult.PackageVersion);
+            Assert.Equal(2, server.SourceUpdateRequests);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_PreindexedExplicitMissingVersion_AfterRefreshStillThrows()
+    {
+        const string packageId = "Test.StillMissingPackage";
+        var initialCatalog = PreindexedCatalogFixture.Create(packageId, "1.0.0");
+        var refreshedCatalog = PreindexedCatalogFixture.Create(packageId, "1.1.0", "1.0.0");
+
+        using var server = new TestPreindexedSourceServer(refreshedCatalog.MsixBytes, initialCatalog.Files.Concat(refreshedCatalog.Files));
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                PreIndexedSourceAutoUpdateInterval = null,
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.PreIndexed));
+            WritePreindexedIndex(appRoot, repo, "test", initialCatalog.IndexBytes);
+
+            var ex = Assert.Throws<SourceSearchException>(() => repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+                Version = "2.0.0",
+            }));
+
+            var missing = Assert.IsType<MissingPackageVersionException>(ex.InnerException);
+            Assert.Equal("2.0.0", missing.RequestedVersion);
+            Assert.Equal(1, server.SourceUpdateRequests);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_PreindexedStaleIndex_RefreshesBeforeLatestSelection()
+    {
+        const string packageId = "Test.StalePackage";
+        var initialCatalog = PreindexedCatalogFixture.Create(packageId, "1.0.0");
+        var refreshedCatalog = PreindexedCatalogFixture.Create(packageId, "1.1.0", "1.0.0");
+
+        using var server = new TestPreindexedSourceServer(refreshedCatalog.MsixBytes, initialCatalog.Files.Concat(refreshedCatalog.Files));
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                PreIndexedSourceAutoUpdateInterval = TimeSpan.FromDays(1),
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.PreIndexed));
+            var indexPath = WritePreindexedIndex(appRoot, repo, "test", initialCatalog.IndexBytes);
+            File.SetLastWriteTimeUtc(indexPath, DateTime.UtcNow.AddDays(-1));
+
+            var result = repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+            });
+
+            Assert.Equal("1.1.0", result.PackageVersion);
+            Assert.Equal(1, server.SourceUpdateRequests);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_PreindexedExplicitMissingVersion_DoesNotRefreshTwiceAfterStaleRefresh()
+    {
+        const string packageId = "Test.NoDoubleRefreshPackage";
+        var initialCatalog = PreindexedCatalogFixture.Create(packageId, "1.0.0");
+        var refreshedCatalog = PreindexedCatalogFixture.Create(packageId, "1.1.0", "1.0.0");
+
+        using var server = new TestPreindexedSourceServer(refreshedCatalog.MsixBytes, initialCatalog.Files.Concat(refreshedCatalog.Files));
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                PreIndexedSourceAutoUpdateInterval = TimeSpan.FromDays(1),
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.PreIndexed));
+            var indexPath = WritePreindexedIndex(appRoot, repo, "test", initialCatalog.IndexBytes);
+            File.SetLastWriteTimeUtc(indexPath, DateTime.UtcNow.AddDays(-1));
+
+            var ex = Assert.Throws<SourceSearchException>(() => repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+                Version = "2.0.0",
+            }));
+
+            var missing = Assert.IsType<MissingPackageVersionException>(ex.InnerException);
+            Assert.Equal("2.0.0", missing.RequestedVersion);
+            Assert.Equal(1, server.SourceUpdateRequests);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_PreindexedStaleIndex_WhenRefreshFails_UsesLocalLatestWithoutExplicitVersion()
+    {
+        const string packageId = "Test.OfflinePackage";
+        var initialCatalog = PreindexedCatalogFixture.Create(packageId, "1.0.0");
+
+        using var server = new TestPreindexedSourceServer(msixBytes: null, initialCatalog.Files);
+        var diagnostics = new List<RepositoryWarning>();
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                Diagnostics = diagnostics.Add,
+                PreIndexedSourceAutoUpdateInterval = TimeSpan.FromDays(1),
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.PreIndexed));
+            var indexPath = WritePreindexedIndex(appRoot, repo, "test", initialCatalog.IndexBytes);
+            File.SetLastWriteTimeUtc(indexPath, DateTime.UtcNow.AddDays(-1));
+
+            var result = repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+            });
+
+            Assert.Equal("1.0.0", result.PackageVersion);
+            Assert.Equal(1, server.SourceUpdateRequests);
+            Assert.Contains(diagnostics, warning => warning.Operation == "source-refresh");
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
+    public void Show_PreindexedV2RequestedChannel_ThrowsInsteadOfIgnoringChannel()
+    {
+        const string packageId = "Test.ChannelPackage";
+        var catalog = PreindexedCatalogFixture.Create(packageId, "1.0.0");
+
+        using var server = new TestPreindexedSourceServer(catalog.MsixBytes, catalog.Files);
+        var appRoot = TestPaths.CreateTempAppRoot();
+        try
+        {
+            using var repo = Repository.Open(new RepositoryOptions
+            {
+                AppRoot = appRoot,
+                PreIndexedSourceAutoUpdateInterval = null,
+            });
+            ReplaceSources(repo, ("test", server.Url, SourceKind.PreIndexed));
+            WritePreindexedIndex(appRoot, repo, "test", catalog.IndexBytes);
+
+            var ex = Assert.Throws<SourceSearchException>(() => repo.ShowManifest(new PackageQuery
+            {
+                Id = packageId,
+                Exact = true,
+                Source = "test",
+                Version = "1.0.0",
+                Channel = "beta",
+            }));
+
+            Assert.Contains("beta", ex.Message);
+            Assert.Contains("channel metadata", ex.Message);
+            Assert.Equal(0, server.SourceUpdateRequests);
+        }
+        finally
+        {
+            TestPaths.DeleteAppRoot(appRoot);
+        }
+    }
+
+    [Fact]
     public void Show_MultipleSourcesExposeStructuredMatches()
     {
         using var firstServer = new TestRestSourceServer();
@@ -2716,6 +3103,16 @@ public class RepositoryEmbeddingTests
             repo.AddSource(source.Name, source.Arg, source.Kind, trustLevel: "trusted");
     }
 
+    private static string WritePreindexedIndex(string appRoot, Repository repo, string sourceName, byte[] indexBytes)
+    {
+        var source = repo.ListSources().Single(source => source.Name == sourceName);
+        var stateDir = SourceStoreManager.SourceStateDir(source, appRoot);
+        Directory.CreateDirectory(stateDir);
+        var indexPath = Path.Combine(stateDir, "index.db");
+        File.WriteAllBytes(indexPath, indexBytes);
+        return indexPath;
+    }
+
     private static JsonDocument RunCliShowJson(string appRoot)
     {
         var root = FindRepositoryRoot();
@@ -2791,12 +3188,236 @@ file static class TestPaths
 
     public static void DeleteAppRoot(string appRoot)
     {
+        SqliteConnection.ClearAllPools();
         if (Directory.Exists(appRoot))
             Directory.Delete(appRoot, recursive: true);
     }
 }
 
 file sealed record TestRestResponse(int StatusCode, string Body, string ContentType = "application/json");
+
+file sealed record PreindexedCatalogFixture(
+    byte[] IndexBytes,
+    byte[] MsixBytes,
+    IReadOnlyList<KeyValuePair<string, byte[]>> Files)
+{
+    public static PreindexedCatalogFixture Create(string packageId, params string[] versions)
+    {
+        if (versions.Length == 0)
+            throw new ArgumentException("At least one version is required.", nameof(versions));
+
+        var files = new List<KeyValuePair<string, byte[]>>();
+        var versionEntries = new StringBuilder();
+
+        foreach (var version in versions)
+        {
+            var manifestPath = $"manifests/{packageId}/{version}.yaml";
+            var manifestBytes = Encoding.UTF8.GetBytes($$"""
+                PackageIdentifier: {{packageId}}
+                PackageVersion: {{version}}
+                DefaultLocale: en-US
+                ManifestType: singleton
+                ManifestVersion: 1.10.0
+                PackageLocale: en-US
+                PackageName: {{packageId}}
+                Publisher: Example
+                License: MIT
+                ShortDescription: test package
+                Installers:
+                  - Architecture: x64
+                    InstallerType: exe
+                    InstallerUrl: https://example.test/{{packageId}}/{{version}}.exe
+                    InstallerSha256: {{new string('A', 64)}}
+                """);
+            files.Add(new KeyValuePair<string, byte[]>(manifestPath, manifestBytes));
+
+            versionEntries.AppendLine($"- v: {version}");
+            versionEntries.AppendLine($"  rP: {manifestPath}");
+            versionEntries.AppendLine($"  s256H: {Sha256Hex(manifestBytes)}");
+        }
+
+        var versionDataYaml = "vD:\n" + versionEntries;
+        var versionDataBytes = CompressMszyml(versionDataYaml);
+        var versionDataHash = SHA256.HashData(versionDataBytes);
+        var versionDataHashHex = Convert.ToHexString(versionDataHash).ToLowerInvariant();
+        var versionDataPath = $"packages/{packageId}/{versionDataHashHex[..8]}/versionData.mszyml";
+        files.Add(new KeyValuePair<string, byte[]>(versionDataPath, versionDataBytes));
+
+        var indexBytes = BuildIndex(packageId, versions[0], versionDataHash);
+        var msixBytes = BuildMsix(indexBytes);
+        return new PreindexedCatalogFixture(indexBytes, msixBytes, files);
+    }
+
+    private static byte[] BuildIndex(string packageId, string latestVersion, byte[] versionDataHash)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"pinget-test-index-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var conn = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = @"
+                    CREATE TABLE packages (
+                        id TEXT NOT NULL,
+                        name TEXT NOT NULL,
+                        moniker TEXT,
+                        latest_version TEXT,
+                        hash BLOB
+                    );
+                    INSERT INTO packages (id, name, moniker, latest_version, hash)
+                    VALUES (@id, @name, NULL, @version, @hash);";
+                cmd.Parameters.AddWithValue("@id", packageId);
+                cmd.Parameters.AddWithValue("@name", packageId);
+                cmd.Parameters.AddWithValue("@version", latestVersion);
+                cmd.Parameters.Add("@hash", SqliteType.Blob).Value = versionDataHash;
+                cmd.ExecuteNonQuery();
+            }
+
+            SqliteConnection.ClearAllPools();
+            return File.ReadAllBytes(dbPath);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    private static byte[] BuildMsix(byte[] indexBytes)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("Public/index.db");
+            using var entryStream = entry.Open();
+            entryStream.Write(indexBytes);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] CompressMszyml(string yaml)
+    {
+        using var stream = new MemoryStream();
+        stream.WriteByte((byte)'C');
+        stream.WriteByte((byte)'K');
+        using (var deflate = new DeflateStream(stream, CompressionMode.Compress, leaveOpen: true))
+        {
+            var bytes = Encoding.UTF8.GetBytes(yaml);
+            deflate.Write(bytes);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static string Sha256Hex(byte[] bytes) =>
+        Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+}
+
+file sealed class TestPreindexedSourceServer : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly Task _loopTask;
+    private readonly CancellationTokenSource _cts = new();
+    private byte[]? _msixBytes;
+    private readonly Dictionary<string, byte[]> _files;
+
+    public TestPreindexedSourceServer(byte[]? msixBytes, IEnumerable<KeyValuePair<string, byte[]>> files)
+    {
+        _msixBytes = msixBytes;
+        _files = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var file in files)
+            _files[file.Key.Replace('\\', '/').TrimStart('/')] = file.Value;
+
+        var port = GetFreePort();
+        Url = $"http://127.0.0.1:{port}";
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"{Url}/");
+        _listener.Start();
+        _loopTask = Task.Run(HandleRequestsAsync, _cts.Token);
+    }
+
+    public string Url { get; }
+    public int SourceUpdateRequests { get; private set; }
+
+    public void SetMsixBytes(byte[]? msixBytes) => _msixBytes = msixBytes;
+
+    private async Task HandleRequestsAsync()
+    {
+        while (!_cts.IsCancellationRequested)
+        {
+            HttpListenerContext? context = null;
+            try
+            {
+                context = await _listener.GetContextAsync();
+                var path = context.Request.Url?.AbsolutePath.TrimStart('/') ?? "";
+                if (path.Equals("source2.msix", StringComparison.OrdinalIgnoreCase))
+                {
+                    SourceUpdateRequests++;
+                    if (_msixBytes is null)
+                    {
+                        context.Response.StatusCode = 503;
+                        continue;
+                    }
+
+                    context.Response.StatusCode = 200;
+                    context.Response.ContentType = "application/octet-stream";
+                    context.Response.Headers.Add("x-ms-meta-sourceversion", "test-source-version");
+                    context.Response.ContentLength64 = _msixBytes.Length;
+                    await context.Response.OutputStream.WriteAsync(_msixBytes, _cts.Token);
+                    continue;
+                }
+
+                if (_files.TryGetValue(path, out var bytes))
+                {
+                    context.Response.StatusCode = 200;
+                    context.Response.ContentType = "application/octet-stream";
+                    context.Response.ContentLength64 = bytes.Length;
+                    await context.Response.OutputStream.WriteAsync(bytes, _cts.Token);
+                    continue;
+                }
+
+                context.Response.StatusCode = 404;
+            }
+            catch (ObjectDisposedException) when (_cts.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (HttpListenerException) when (_cts.IsCancellationRequested)
+            {
+                break;
+            }
+            finally
+            {
+                context?.Response.OutputStream.Dispose();
+                context?.Response.Close();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        _listener.Close();
+        try
+        {
+            _loopTask.GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+}
 
 file sealed class TestRestSourceServer : IDisposable
 {

--- a/dotnet/src/Devolutions.Pinget.Core/Models.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Models.cs
@@ -40,6 +40,12 @@ public record RepositoryOptions
     public string? AppRoot { get; init; }
     public string UserAgent { get; init; } = "pinget-dotnet/0.1";
     public Action<RepositoryWarning>? Diagnostics { get; init; }
+
+    /// <summary>
+    /// Maximum age for an existing pre-indexed source index before Pinget attempts a background refresh.
+    /// Set to null to disable automatic freshness checks.
+    /// </summary>
+    public TimeSpan? PreIndexedSourceAutoUpdateInterval { get; init; } = TimeSpan.FromMinutes(5);
 }
 
 public record RepositoryWarning
@@ -65,6 +71,44 @@ public class SourceSearchException : InvalidOperationException
     }
 
     public RepositoryWarning Warning { get; }
+}
+
+public class MissingPackageVersionException : InvalidOperationException
+{
+    public MissingPackageVersionException(
+        string packageId,
+        string sourceName,
+        string requestedVersion,
+        string? requestedChannel = null,
+        Exception? refreshException = null)
+        : base(BuildMessage(packageId, sourceName, requestedVersion, requestedChannel, refreshException))
+    {
+        PackageId = packageId;
+        SourceName = sourceName;
+        RequestedVersion = requestedVersion;
+        RequestedChannel = requestedChannel;
+        RefreshException = refreshException;
+    }
+
+    public string PackageId { get; }
+    public string SourceName { get; }
+    public string RequestedVersion { get; }
+    public string? RequestedChannel { get; }
+    public Exception? RefreshException { get; }
+
+    private static string BuildMessage(
+        string packageId,
+        string sourceName,
+        string requestedVersion,
+        string? requestedChannel,
+        Exception? refreshException)
+    {
+        var channelPart = string.IsNullOrWhiteSpace(requestedChannel) ? "" : $" with channel '{requestedChannel}'";
+        var message = $"Version '{requestedVersion}'{channelPart} was not found for package '{packageId}' in source '{sourceName}'.";
+        return refreshException is null
+            ? message
+            : $"{message} The source refresh also failed: {refreshException.Message}";
+    }
 }
 
 public class MultiplePackageMatchesException : InvalidOperationException

--- a/dotnet/src/Devolutions.Pinget.Core/PreIndexedSource.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/PreIndexedSource.cs
@@ -42,7 +42,17 @@ internal static class PreIndexedSource
                     ?? throw new InvalidOperationException($"No Public/index.db in {candidate}");
 
                 var indexPath = IndexPath(source, appRoot);
-                indexEntry.ExtractToFile(indexPath, overwrite: true);
+                var tempIndexPath = Path.Combine(stateDir, $"index.{Guid.NewGuid():N}.tmp");
+                try
+                {
+                    indexEntry.ExtractToFile(tempIndexPath, overwrite: true);
+                    File.Move(tempIndexPath, indexPath, overwrite: true);
+                }
+                finally
+                {
+                    if (File.Exists(tempIndexPath))
+                        File.Delete(tempIndexPath);
+                }
 
                 source.SourceVersion = headerVersion;
                 return $"Updated from {candidate}" + (headerVersion != null ? $" (v{headerVersion})" : "");

--- a/dotnet/src/Devolutions.Pinget.Core/PreIndexedSource.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/PreIndexedSource.cs
@@ -399,6 +399,9 @@ internal static class PreIndexedSource
         using var response = client.GetAsync(url).GetAwaiter().GetResult();
         response.EnsureSuccessStatusCode();
         var bytes = response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult();
+        if (!HashMatches(expectedHash, bytes))
+            throw new InvalidOperationException(
+                $"Hash mismatch for source file '{normalizedRelative}'. Expected: {expectedHash}.");
 
         // Persist to cache
         Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
@@ -448,7 +451,7 @@ internal static class PreIndexedSource
 
     private static bool HashMatches(string? expected, byte[] data)
     {
-        if (expected is null) return true;
+        if (string.IsNullOrWhiteSpace(expected)) return true;
         using var sha256 = System.Security.Cryptography.SHA256.Create();
         var hash = Convert.ToHexString(sha256.ComputeHash(data)).ToLowerInvariant();
         return hash.Equals(expected, StringComparison.OrdinalIgnoreCase);

--- a/dotnet/src/Devolutions.Pinget.Core/Repository.cs
+++ b/dotnet/src/Devolutions.Pinget.Core/Repository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -24,20 +25,27 @@ public class Repository : IDisposable
     private readonly HttpClient _client;
     private readonly bool _useSystemWingetSources;
     private readonly Action<RepositoryWarning>? _diagnostics;
+    private readonly TimeSpan? _preIndexedSourceAutoUpdateInterval;
     private SourceStore _store;
+    private static readonly ConcurrentDictionary<string, object> s_preIndexedRefreshLocks = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly TimeSpan s_preIndexedRefreshRetryInterval = TimeSpan.FromMinutes(5);
+    private readonly object _preIndexedRefreshAttemptGate = new();
+    private readonly Dictionary<string, (DateTime AttemptedAt, Exception? Exception, PreIndexedRefreshKind Kind)> _preIndexedRefreshAttempts = new(StringComparer.OrdinalIgnoreCase);
 
     private Repository(
         string appRoot,
         HttpClient client,
         SourceStore store,
         bool useSystemWingetSources,
-        Action<RepositoryWarning>? diagnostics)
+        Action<RepositoryWarning>? diagnostics,
+        TimeSpan? preIndexedSourceAutoUpdateInterval)
     {
         _appRoot = appRoot;
         _client = client;
         _store = store;
         _useSystemWingetSources = useSystemWingetSources;
         _diagnostics = diagnostics;
+        _preIndexedSourceAutoUpdateInterval = preIndexedSourceAutoUpdateInterval;
     }
 
     /// <summary>
@@ -53,7 +61,7 @@ public class Repository : IDisposable
         var store = SourceStoreManager.Load(appRoot);
         var client = new HttpClient();
         client.DefaultRequestHeaders.UserAgent.ParseAdd(options.UserAgent);
-        return new Repository(appRoot, client, store, useSystemWingetSources, options.Diagnostics);
+        return new Repository(appRoot, client, store, useSystemWingetSources, options.Diagnostics, options.PreIndexedSourceAutoUpdateInterval);
     }
 
     internal static IEnumerable<string> GetSqliteNativeLibraryCandidates(string assemblyDirectory)
@@ -1227,7 +1235,7 @@ public class Repository : IDisposable
     private (List<LocatedMatch> Matches, bool Truncated) SearchPreindexed(
         int sourceIndex, PackageQuery query, SearchSemantics semantics)
     {
-        var conn = OpenPreindexedConnection(sourceIndex);
+        using var conn = OpenPreindexedConnection(sourceIndex);
         var source = _store.Sources[sourceIndex];
 
         // Try V2 first, fall back to V1
@@ -1366,22 +1374,152 @@ public class Repository : IDisposable
     private static Exception UnwrapSourceOperationException(Exception exception) =>
         exception is SourceOperationException { InnerException: { } innerException } ? innerException : exception;
 
-    private SqliteConnection OpenPreindexedConnection(int sourceIndex)
+    private enum PreIndexedRefreshKind
+    {
+        Auto,
+        Explicit
+    }
+
+    private sealed record PreIndexedRefreshOutcome(bool Attempted, bool Succeeded, Exception? Exception, bool ReusedRecentAttempt)
+    {
+        public static readonly PreIndexedRefreshOutcome NotAttempted = new(false, false, null, false);
+    }
+
+    private SqliteConnection OpenPreindexedConnection(int sourceIndex) =>
+        OpenPreindexedConnection(sourceIndex, out _);
+
+    private SqliteConnection OpenPreindexedConnection(int sourceIndex, out PreIndexedRefreshOutcome refreshOutcome)
     {
         var source = _store.Sources[sourceIndex];
         var indexPath = PreIndexedSource.IndexPath(source, _appRoot);
-        if (!File.Exists(indexPath))
-        {
-            PreIndexedSource.Update(_client, source, _appRoot);
-            source.LastUpdate = DateTime.UtcNow;
-            if (!_useSystemWingetSources)
-                SourceStoreManager.Save(_store, _appRoot);
-        }
+        refreshOutcome = EnsurePreindexedIndex(sourceIndex, indexPath);
 
-        var conn = new SqliteConnection($"Data Source={indexPath};Mode=ReadOnly");
+        var conn = new SqliteConnection($"Data Source={indexPath};Mode=ReadOnly;Pooling=False");
         conn.Open();
         return conn;
     }
+
+    private PreIndexedRefreshOutcome EnsurePreindexedIndex(int sourceIndex, string indexPath)
+    {
+        var indexExists = File.Exists(indexPath);
+        if (!indexExists)
+        {
+            RefreshPreindexedSource(sourceIndex, force: true, PreIndexedRefreshKind.Auto);
+            return new PreIndexedRefreshOutcome(true, true, null, false);
+        }
+
+        var source = _store.Sources[sourceIndex];
+        if (!IsPreindexedIndexStale(source, indexPath))
+            return PreIndexedRefreshOutcome.NotAttempted;
+
+        var lockKey = PreindexedRefreshLockKey(source);
+        if (TryGetRecentPreindexedRefreshAttempt(lockKey, out var recentOutcome))
+            return recentOutcome;
+
+        try
+        {
+            RefreshPreindexedSource(sourceIndex, force: false, PreIndexedRefreshKind.Auto);
+            return new PreIndexedRefreshOutcome(true, true, null, false);
+        }
+        catch (Exception ex)
+        {
+            var warning = CreateSourceWarning(sourceIndex, "source-refresh", ex);
+            EmitDiagnostic(warning);
+            return new PreIndexedRefreshOutcome(true, false, ex, false);
+        }
+    }
+
+    private bool IsPreindexedIndexStale(SourceRecord source, string indexPath)
+    {
+        if (_preIndexedSourceAutoUpdateInterval is null)
+            return false;
+
+        var lastUpdate = source.LastUpdate;
+        if (lastUpdate is null && File.Exists(indexPath))
+            lastUpdate = File.GetLastWriteTimeUtc(indexPath);
+
+        if (lastUpdate is null)
+            return true;
+
+        return DateTime.UtcNow - lastUpdate.Value.ToUniversalTime() >= _preIndexedSourceAutoUpdateInterval.Value;
+    }
+
+    private string RefreshPreindexedSource(int sourceIndex, bool force, PreIndexedRefreshKind kind)
+    {
+        var source = _store.Sources[sourceIndex];
+        var indexPath = PreIndexedSource.IndexPath(source, _appRoot);
+        var lockKey = PreindexedRefreshLockKey(source);
+        var refreshLock = s_preIndexedRefreshLocks.GetOrAdd(lockKey, _ => new object());
+
+        lock (refreshLock)
+        {
+            if (!force && File.Exists(indexPath) && !IsPreindexedIndexStale(source, indexPath))
+                return "Source already refreshed";
+
+            try
+            {
+                var detail = PreIndexedSource.Update(_client, source, _appRoot);
+                source.LastUpdate = DateTime.UtcNow;
+                if (!_useSystemWingetSources)
+                    SourceStoreManager.Save(_store, _appRoot);
+                RecordPreindexedRefreshAttempt(lockKey, null, kind);
+                return detail;
+            }
+            catch (Exception ex)
+            {
+                RecordPreindexedRefreshAttempt(lockKey, ex, kind);
+                throw;
+            }
+        }
+    }
+
+    private string PreindexedRefreshLockKey(SourceRecord source) =>
+        $"{_appRoot}|{source.Identifier}|{source.Name}";
+
+    private bool TryGetRecentPreindexedRefreshAttempt(string lockKey, out PreIndexedRefreshOutcome outcome)
+    {
+        lock (_preIndexedRefreshAttemptGate)
+        {
+            if (_preIndexedRefreshAttempts.TryGetValue(lockKey, out var attempt) &&
+                DateTime.UtcNow - attempt.AttemptedAt < s_preIndexedRefreshRetryInterval)
+            {
+                outcome = new PreIndexedRefreshOutcome(true, attempt.Exception is null, attempt.Exception, attempt.Kind == PreIndexedRefreshKind.Auto);
+                return true;
+            }
+        }
+
+        outcome = PreIndexedRefreshOutcome.NotAttempted;
+        return false;
+    }
+
+    private bool HasRecentSuccessfulPreindexedRefreshAttempt(SourceRecord source) =>
+        TryGetRecentPreindexedRefreshAttempt(PreindexedRefreshLockKey(source), out var outcome) && outcome.Succeeded;
+
+    private void RecordPreindexedRefreshAttempt(string lockKey, Exception? exception, PreIndexedRefreshKind kind)
+    {
+        lock (_preIndexedRefreshAttemptGate)
+            _preIndexedRefreshAttempts[lockKey] = (DateTime.UtcNow, exception, kind);
+    }
+
+    private void EmitPreindexedRefreshDiagnostic(int sourceIndex, string packageId, string requestedVersion, string? requestedChannel)
+    {
+        var source = _store.Sources[sourceIndex];
+        var channelPart = string.IsNullOrWhiteSpace(requestedChannel) ? "" : $" channel '{requestedChannel}'";
+        EmitDiagnostic(new RepositoryWarning
+        {
+            Operation = "manifest-refresh",
+            SourceName = source.Name,
+            SourceKind = source.Kind,
+            SourceArg = source.Arg,
+            SourceIdentifier = source.Identifier,
+            RequestUri = SourceRequestUri(source, "source-refresh"),
+            CachePath = SourceDiagnosticCachePath(source),
+            Message = $"Package '{packageId}' version '{requestedVersion}'{channelPart} was missing from the local pre-indexed source cache; refreshing source '{source.Name}'.",
+        });
+    }
+
+    private static MissingPackageVersionException WithRefreshFailure(MissingPackageVersionException exception, Exception refreshException) =>
+        new(exception.PackageId, exception.SourceName, exception.RequestedVersion, exception.RequestedChannel, refreshException);
 
     private (LocatedMatch Match, List<string> Warnings, List<RepositoryWarning> SourceWarnings) FindSingleMatch(PackageQuery query)
         => FindSingleMatchWithSemantics(query, SearchSemantics.Single);
@@ -1421,7 +1559,7 @@ public class Repository : IDisposable
 
     private List<VersionKey> VersionsFromV1(int sourceIndex, long packageRowid)
     {
-        var conn = OpenPreindexedConnection(sourceIndex);
+        using var conn = OpenPreindexedConnection(sourceIndex);
         var rows = PreIndexedSource.QueryV1Versions(conn, packageRowid);
         return rows.Select(r => new VersionKey { Version = r.Version, Channel = r.Channel }).ToList();
     }
@@ -1429,28 +1567,65 @@ public class Repository : IDisposable
     private List<VersionKey> VersionsFromV2(int sourceIndex, long packageRowid, string packageHash)
     {
         var source = _store.Sources[sourceIndex];
-        var conn = OpenPreindexedConnection(sourceIndex);
+        using var conn = OpenPreindexedConnection(sourceIndex);
         var (entries, _) = PreIndexedSource.LoadV2VersionData(_client, conn, source, packageRowid, packageHash, _appRoot);
         return entries.Select(e => new VersionKey { Version = e.Version, Channel = "" }).ToList();
     }
 
-    private (Manifest Manifest, object StructuredDocument, List<string> CachedFiles) ManifestForMatch(LocatedMatch located, PackageQuery query)
+    private (Manifest Manifest, object StructuredDocument, List<string> CachedFiles) ManifestForMatch(
+        LocatedMatch located,
+        PackageQuery query,
+        bool allowExplicitVersionRefresh = true)
     {
         return located.Locator switch
         {
-            PreIndexedV1Locator v1 => ManifestFromV1(located.SourceIndex, v1.PackageRowId, query),
-            PreIndexedV2Locator v2 => ManifestFromV2(located.SourceIndex, v2.PackageRowId, v2.PackageHash, query),
-            RestLocator rest => ManifestFromRest(located.SourceIndex, rest.PackageId, rest.Versions, query),
+            PreIndexedV1Locator v1 => ManifestFromV1(located.SourceIndex, v1.PackageRowId, located.Display, query, allowExplicitVersionRefresh),
+            PreIndexedV2Locator v2 => ManifestFromV2(located.SourceIndex, v2.PackageRowId, v2.PackageHash, located.Display, query, allowExplicitVersionRefresh),
+            RestLocator rest => ManifestFromRest(located.SourceIndex, rest.PackageId, rest.Versions, located.Display, query),
             _ => throw new InvalidOperationException("Unknown locator type")
         };
     }
 
-    private (Manifest, object, List<string>) ManifestFromV1(int sourceIndex, long packageRowid, PackageQuery query)
+    private (Manifest, object, List<string>) ManifestFromV1(
+        int sourceIndex,
+        long packageRowid,
+        SearchMatch display,
+        PackageQuery query,
+        bool allowExplicitVersionRefresh)
     {
-        var conn = OpenPreindexedConnection(sourceIndex);
+        PreIndexedRefreshOutcome openRefresh;
+        SqliteConnection? conn = OpenPreindexedConnection(sourceIndex, out openRefresh);
+        try
+        {
+            return ManifestFromV1Connection(sourceIndex, conn, packageRowid, display, query);
+        }
+        catch (MissingPackageVersionException ex) when (allowExplicitVersionRefresh && query.Version is not null)
+        {
+            conn.Dispose();
+            conn = null;
+            if (openRefresh.Attempted && !openRefresh.ReusedRecentAttempt)
+                throw openRefresh.Exception is null ? ex : WithRefreshFailure(ex, openRefresh.Exception);
+            if (HasRecentSuccessfulPreindexedRefreshAttempt(_store.Sources[sourceIndex]))
+                throw;
+
+            return RefreshPreindexedAndRetryManifest(sourceIndex, display, query, ex);
+        }
+        finally
+        {
+            conn?.Dispose();
+        }
+    }
+
+    private (Manifest, object, List<string>) ManifestFromV1Connection(
+        int sourceIndex,
+        SqliteConnection conn,
+        long packageRowid,
+        SearchMatch display,
+        PackageQuery query)
+    {
         var source = _store.Sources[sourceIndex];
         var versions = PreIndexedSource.QueryV1Versions(conn, packageRowid);
-        var selected = SelectV1Version(versions, query.Version, query.Channel);
+        var selected = SelectV1Version(versions, query.Version, query.Channel, display.Id, source.Name);
         var relativePath = PreIndexedSource.ResolveV1RelativePath(conn, selected.PathPart);
         var bytes = PreIndexedSource.GetCachedSourceFile(_client, "V1_M", source, relativePath, selected.ManifestHash);
         var manifest = ParseYamlManifest(bytes);
@@ -1459,12 +1634,48 @@ public class Repository : IDisposable
         return (manifest, structuredDocument, []);
     }
 
-    private (Manifest, object, List<string>) ManifestFromV2(int sourceIndex, long packageRowid, string packageHash, PackageQuery query)
+    private (Manifest, object, List<string>) ManifestFromV2(
+        int sourceIndex,
+        long packageRowid,
+        string packageHash,
+        SearchMatch display,
+        PackageQuery query,
+        bool allowExplicitVersionRefresh)
+    {
+        PreIndexedRefreshOutcome openRefresh;
+        SqliteConnection? conn = OpenPreindexedConnection(sourceIndex, out openRefresh);
+        try
+        {
+            return ManifestFromV2Connection(sourceIndex, conn, packageRowid, packageHash, display, query);
+        }
+        catch (MissingPackageVersionException ex) when (allowExplicitVersionRefresh && query.Version is not null)
+        {
+            conn.Dispose();
+            conn = null;
+            if (openRefresh.Attempted && !openRefresh.ReusedRecentAttempt)
+                throw openRefresh.Exception is null ? ex : WithRefreshFailure(ex, openRefresh.Exception);
+            if (HasRecentSuccessfulPreindexedRefreshAttempt(_store.Sources[sourceIndex]))
+                throw;
+
+            return RefreshPreindexedAndRetryManifest(sourceIndex, display, query, ex);
+        }
+        finally
+        {
+            conn?.Dispose();
+        }
+    }
+
+    private (Manifest, object, List<string>) ManifestFromV2Connection(
+        int sourceIndex,
+        SqliteConnection conn,
+        long packageRowid,
+        string packageHash,
+        SearchMatch display,
+        PackageQuery query)
     {
         var source = _store.Sources[sourceIndex];
-        var conn = OpenPreindexedConnection(sourceIndex);
         var (entries, vdFile) = PreIndexedSource.LoadV2VersionData(_client, conn, source, packageRowid, packageHash, _appRoot);
-        var selected = SelectV2Version(entries, query.Version);
+        var selected = SelectV2Version(entries, query.Version, query.Channel, display.Id, source.Name);
         var bytes = PreIndexedSource.GetCachedSourceFile(_client, "V2_M", source, selected.ManifestRelativePath, selected.ManifestHash);
         var manifest = ParseYamlManifest(bytes);
         var structuredDocument = ParseYamlManifestDocuments(bytes);
@@ -1472,64 +1683,140 @@ public class Repository : IDisposable
         return (manifest, structuredDocument, [vdFile]);
     }
 
-    private (Manifest, object, List<string>) ManifestFromRest(int sourceIndex, string packageId, List<VersionKey> versions, PackageQuery query)
+    private (Manifest, object, List<string>) ManifestFromRest(
+        int sourceIndex,
+        string packageId,
+        List<VersionKey> versions,
+        SearchMatch display,
+        PackageQuery query)
     {
         var source = _store.Sources[sourceIndex];
         var info = RestSource.LoadInformation(_client, source, _appRoot);
-        var selected = SelectRestVersion(versions, query.Version, query.Channel);
+        var selected = SelectRestVersion(versions, query.Version, query.Channel, display.Id, source.Name);
         var (manifest, structuredDocument) = RestSource.FetchManifestWithDocuments(_client, source, info, packageId, selected.Version, selected.Channel);
         return (manifest, structuredDocument, []);
+    }
+
+    private (Manifest, object, List<string>) RefreshPreindexedAndRetryManifest(
+        int sourceIndex,
+        SearchMatch display,
+        PackageQuery query,
+        MissingPackageVersionException missingVersion)
+    {
+        EmitPreindexedRefreshDiagnostic(sourceIndex, display.Id, missingVersion.RequestedVersion, missingVersion.RequestedChannel);
+        try
+        {
+            RefreshPreindexedSource(sourceIndex, force: true, PreIndexedRefreshKind.Explicit);
+        }
+        catch (Exception ex)
+        {
+            throw WithRefreshFailure(missingVersion, ex);
+        }
+
+        var refreshed = FindRefreshedPreindexedMatch(sourceIndex, display, query);
+        return ManifestForMatch(refreshed, query, allowExplicitVersionRefresh: false);
+    }
+
+    private LocatedMatch FindRefreshedPreindexedMatch(int sourceIndex, SearchMatch previousDisplay, PackageQuery query)
+    {
+        var sourceQuery = query with { Source = _store.Sources[sourceIndex].Name };
+        var (matches, _) = SearchPreindexed(sourceIndex, sourceQuery, SearchSemantics.Single);
+        var refreshed = matches.FirstOrDefault(match =>
+            string.Equals(match.Display.Id, previousDisplay.Id, StringComparison.OrdinalIgnoreCase));
+
+        if (refreshed is not null)
+            return refreshed;
+
+        if (matches.Count == 1)
+            return matches[0];
+
+        throw new InvalidOperationException($"Package '{previousDisplay.Id}' was not found in source '{_store.Sources[sourceIndex].Name}' after refreshing the pre-indexed source.");
     }
 
     // ── Version selection ──
 
     private static PreIndexedSource.V1VersionRow SelectV1Version(
-        List<PreIndexedSource.V1VersionRow> versions, string? requestedVersion, string? requestedChannel)
+        List<PreIndexedSource.V1VersionRow> versions,
+        string? requestedVersion,
+        string? requestedChannel,
+        string packageId,
+        string sourceName)
     {
         if (versions.Count == 0)
             throw new InvalidOperationException("No versions found");
 
-        if (requestedVersion is not null)
+        if (requestedVersion is null)
         {
-            var match = versions.FirstOrDefault(v => v.Version == requestedVersion
-                && (requestedChannel is null || v.Channel == requestedChannel));
-            if (match is not null) return match;
+            if (requestedChannel is null)
+                return versions[0]; // latest
+
+            var channelMatch = versions.FirstOrDefault(v => v.Channel == requestedChannel);
+            return channelMatch ?? throw new InvalidOperationException(
+                $"Channel '{requestedChannel}' was not found for package '{packageId}' in source '{sourceName}'.");
         }
 
-        return versions[0]; // latest
+        var match = versions.FirstOrDefault(v => v.Version == requestedVersion
+            && (requestedChannel is null || v.Channel == requestedChannel));
+        if (match is not null)
+            return match;
+
+        throw new MissingPackageVersionException(packageId, sourceName, requestedVersion, requestedChannel);
     }
 
     private static PreIndexedSource.V2VersionDataEntry SelectV2Version(
-        List<PreIndexedSource.V2VersionDataEntry> entries, string? requestedVersion)
+        List<PreIndexedSource.V2VersionDataEntry> entries,
+        string? requestedVersion,
+        string? requestedChannel,
+        string packageId,
+        string sourceName)
     {
         if (entries.Count == 0)
             throw new InvalidOperationException("No versions found");
 
+        if (requestedChannel is not null)
+            throw new InvalidOperationException(
+                $"Channel '{requestedChannel}' cannot be matched for package '{packageId}' in pre-indexed V2 source '{sourceName}' because the local source index does not include channel metadata.");
+
         if (requestedVersion is not null)
         {
             var match = entries.FirstOrDefault(e => e.Version == requestedVersion);
-            if (match is not null) return match;
+            if (match is not null)
+                return match;
+
+            throw new MissingPackageVersionException(packageId, sourceName, requestedVersion);
         }
 
-        // Sort and return latest
         var sorted = entries.OrderByDescending(e => e.Version, new VersionComparer()).ToList();
         return sorted[0];
     }
 
-    private static VersionKey SelectRestVersion(List<VersionKey> versions, string? requestedVersion, string? requestedChannel)
+    private static VersionKey SelectRestVersion(
+        List<VersionKey> versions,
+        string? requestedVersion,
+        string? requestedChannel,
+        string packageId,
+        string sourceName)
     {
         if (versions.Count == 0)
             throw new InvalidOperationException("No versions found");
 
-        if (requestedVersion is not null)
+        if (requestedVersion is null)
         {
-            var match = versions.FirstOrDefault(v => v.Version == requestedVersion
-                && (requestedChannel is null || v.Channel == requestedChannel));
-            if (match is not null) return match;
+            var sorted = versions.OrderByDescending(v => v.Version, new VersionComparer()).ToList();
+            if (requestedChannel is null)
+                return sorted[0];
+
+            var channelMatch = sorted.FirstOrDefault(v => v.Channel == requestedChannel);
+            return channelMatch ?? throw new InvalidOperationException(
+                $"Channel '{requestedChannel}' was not found for package '{packageId}' in source '{sourceName}'.");
         }
 
-        var sorted = versions.OrderByDescending(v => v.Version, new VersionComparer()).ToList();
-        return sorted[0];
+        var match = versions.FirstOrDefault(v => v.Version == requestedVersion
+            && (requestedChannel is null || v.Channel == requestedChannel));
+        if (match is not null)
+            return match;
+
+        throw new MissingPackageVersionException(packageId, sourceName, requestedVersion, requestedChannel);
     }
 
     // ── Installer selection ──
@@ -2475,6 +2762,24 @@ public class Repository : IDisposable
 
     internal static bool InstalledPackageMatchesUpgradeFilterForTesting(InstalledPackage pkg, ListQuery query)
         => InstalledPackageMatchesUpgradeFilter(pkg, query);
+
+    internal static PreIndexedSource.V1VersionRow SelectV1VersionForTesting(
+        List<PreIndexedSource.V1VersionRow> versions,
+        string? requestedVersion,
+        string? requestedChannel = null)
+        => SelectV1Version(versions, requestedVersion, requestedChannel, "Test.Package", "test");
+
+    internal static PreIndexedSource.V2VersionDataEntry SelectV2VersionForTesting(
+        List<PreIndexedSource.V2VersionDataEntry> entries,
+        string? requestedVersion,
+        string? requestedChannel = null)
+        => SelectV2Version(entries, requestedVersion, requestedChannel, "Test.Package", "test");
+
+    internal static VersionKey SelectRestVersionForTesting(
+        List<VersionKey> versions,
+        string? requestedVersion,
+        string? requestedChannel = null)
+        => SelectRestVersion(versions, requestedVersion, requestedChannel, "Test.Package", "test");
 
     private static long? LookupUniqueNormalizedIdentity(Microsoft.Data.Sqlite.SqliteConnection conn, string normName, string normPublisher)
     {

--- a/rust/crates/pinget-core/Cargo.toml
+++ b/rust/crates/pinget-core/Cargo.toml
@@ -31,4 +31,4 @@ zip = "8.5.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55.0"
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_Packaging_Appx", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_Storage_Packaging_Appx", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -1,7 +1,7 @@
 mod name_normalization;
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::fs;
 use std::io::{Cursor, Read};
@@ -10,7 +10,7 @@ use std::mem::{MaybeUninit, size_of};
 #[cfg(windows)]
 use std::os::windows::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Duration, Utc};
@@ -39,6 +39,8 @@ const DEFAULT_MAX_RESULTS: usize = 50;
 const LIST_LOOKUP_MAX_RESULTS: usize = 500;
 const PREINDEXED_CANDIDATES: &[&str] = &["source2.msix", "source.msix"];
 const DEFAULT_USER_AGENT: &str = "pinget-rs/0.1";
+const DEFAULT_PREINDEXED_AUTO_UPDATE_MINUTES: i64 = 5;
+const PREINDEXED_REFRESH_RETRY_MINUTES: i64 = 5;
 #[cfg(windows)]
 const PACKAGED_FAMILY_NAME: &str = "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe";
 #[cfg(windows)]
@@ -141,6 +143,7 @@ impl Default for SourceStore {
 pub struct RepositoryOptions {
     pub app_root: PathBuf,
     pub user_agent: String,
+    pub pre_indexed_source_auto_update_interval: Option<Duration>,
 }
 
 impl RepositoryOptions {
@@ -149,6 +152,7 @@ impl RepositoryOptions {
         Self {
             app_root: app_root.into(),
             user_agent: DEFAULT_USER_AGENT.to_owned(),
+            pre_indexed_source_auto_update_interval: Some(Duration::minutes(DEFAULT_PREINDEXED_AUTO_UPDATE_MINUTES)),
         }
     }
 
@@ -161,6 +165,13 @@ impl RepositoryOptions {
     #[must_use]
     pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
         self.user_agent = user_agent.into();
+        self
+    }
+
+    /// Overrides automatic freshness checks for existing pre-indexed source indexes.
+    #[must_use]
+    pub fn with_pre_indexed_source_auto_update_interval(mut self, interval: Option<Duration>) -> Self {
+        self.pre_indexed_source_auto_update_interval = interval;
         self
     }
 }
@@ -713,6 +724,57 @@ pub struct Repository {
     client: Client,
     store: SourceStore,
     use_system_winget_sources: bool,
+    pre_indexed_source_auto_update_interval: Option<Duration>,
+    preindexed_refresh_attempts: HashMap<String, PreindexedRefreshAttempt>,
+}
+
+#[derive(Debug, Clone)]
+struct PreindexedRefreshAttempt {
+    attempted_at: DateTime<Utc>,
+    succeeded: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PreindexedRefreshOutcome {
+    attempted: bool,
+    reused_recent_attempt: bool,
+    error: Option<String>,
+}
+
+struct PreindexedOpenConnection {
+    connection: Connection,
+    refresh: PreindexedRefreshOutcome,
+}
+
+#[derive(Debug)]
+struct MissingPackageVersionError {
+    package_id: String,
+    source_name: String,
+    requested_version: String,
+    requested_channel: Option<String>,
+}
+
+impl Display for MissingPackageVersionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let channel = self
+            .requested_channel
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .map(|value| format!(" with channel '{value}'"))
+            .unwrap_or_default();
+        write!(
+            f,
+            "Version '{}'{} was not found for package '{}' in source '{}'.",
+            self.requested_version, channel, self.package_id, self.source_name
+        )
+    }
+}
+
+impl std::error::Error for MissingPackageVersionError {}
+
+fn preindexed_refresh_locks() -> &'static RwLock<HashMap<String, Arc<Mutex<()>>>> {
+    static LOCKS: OnceLock<RwLock<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+    LOCKS.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
 impl Repository {
@@ -735,6 +797,8 @@ impl Repository {
             client,
             store,
             use_system_winget_sources,
+            pre_indexed_source_auto_update_interval: options.pre_indexed_source_auto_update_interval,
+            preindexed_refresh_attempts: HashMap::new(),
         })
     }
 
@@ -2371,13 +2435,53 @@ impl Repository {
         located: &LocatedMatch,
         query: &PackageQuery,
     ) -> Result<(Manifest, JsonValue, Vec<PathBuf>)> {
+        self.manifest_for_match_with_refresh(located, query, true)
+    }
+
+    fn manifest_for_match_with_refresh(
+        &mut self,
+        located: &LocatedMatch,
+        query: &PackageQuery,
+        allow_explicit_version_refresh: bool,
+    ) -> Result<(Manifest, JsonValue, Vec<PathBuf>)> {
         match &located.locator {
             MatchLocator::PreIndexedV1 { package_rowid } => {
                 let source = self.source_clone(located.source_index);
-                let connection = self.open_preindexed_connection(located.source_index)?;
-                let versions = query_v1_versions(&connection, *package_rowid)?;
-                let selected = select_v1_version(&versions, query.version.as_deref(), query.channel.as_deref())?;
-                let relative_path = resolve_v1_relative_path(&connection, selected.pathpart_id)?;
+                let opened = self.open_preindexed_connection_with_refresh(located.source_index)?;
+                let versions = query_v1_versions(&opened.connection, *package_rowid)?;
+                let selected = match select_v1_version(
+                    &versions,
+                    query.version.as_deref(),
+                    query.channel.as_deref(),
+                    &located.display.id,
+                    &source.name,
+                ) {
+                    Ok(selected) => selected,
+                    Err(error)
+                        if allow_explicit_version_refresh
+                            && query.version.is_some()
+                            && error.downcast_ref::<MissingPackageVersionError>().is_some() =>
+                    {
+                        let open_refresh = opened.refresh.clone();
+                        if open_refresh.attempted && !open_refresh.reused_recent_attempt {
+                            return missing_error_after_open_refresh(error, &open_refresh);
+                        }
+                        if self.has_recent_successful_preindexed_refresh_attempt(
+                            &self.preindexed_refresh_lock_key(&source),
+                        ) {
+                            return Err(error);
+                        }
+                        drop(opened);
+                        return self.refresh_preindexed_and_retry_manifest(
+                            located.source_index,
+                            &located.display,
+                            query,
+                            error,
+                        );
+                    }
+                    Err(error) => return Err(error),
+                };
+                let relative_path = resolve_v1_relative_path(&opened.connection, selected.pathpart_id)?;
                 let bytes =
                     self.get_cached_source_file("V1_M", &source, &relative_path, selected.manifest_hash.as_deref())?;
                 let (mut manifest, manifest_documents) = parse_yaml_manifest_bundle(&bytes.bytes)?;
@@ -2390,9 +2494,41 @@ impl Repository {
                 package_hash,
             } => {
                 let source = self.source_clone(located.source_index);
+                let opened = self.open_preindexed_connection_with_refresh(located.source_index)?;
                 let (entries, version_data_file) =
                     self.load_v2_version_data(&source, *package_rowid, package_hash.as_str())?;
-                let selected = select_v2_version(&entries, query.version.as_deref())?;
+                let selected = match select_v2_version(
+                    &entries,
+                    query.version.as_deref(),
+                    query.channel.as_deref(),
+                    &located.display.id,
+                    &source.name,
+                ) {
+                    Ok(selected) => selected,
+                    Err(error)
+                        if allow_explicit_version_refresh
+                            && query.version.is_some()
+                            && error.downcast_ref::<MissingPackageVersionError>().is_some() =>
+                    {
+                        let open_refresh = opened.refresh.clone();
+                        if open_refresh.attempted && !open_refresh.reused_recent_attempt {
+                            return missing_error_after_open_refresh(error, &open_refresh);
+                        }
+                        if self.has_recent_successful_preindexed_refresh_attempt(
+                            &self.preindexed_refresh_lock_key(&source),
+                        ) {
+                            return Err(error);
+                        }
+                        drop(opened);
+                        return self.refresh_preindexed_and_retry_manifest(
+                            located.source_index,
+                            &located.display,
+                            query,
+                            error,
+                        );
+                    }
+                    Err(error) => return Err(error),
+                };
                 let manifest_bytes = self.get_cached_source_file(
                     "V2_M",
                     &source,
@@ -2409,7 +2545,13 @@ impl Repository {
             }
             MatchLocator::Rest { package_id, versions } => {
                 let source = self.source_clone(located.source_index);
-                let selected = select_rest_version(versions, query.version.as_deref(), query.channel.as_deref())?;
+                let selected = select_rest_version(
+                    versions,
+                    query.version.as_deref(),
+                    query.channel.as_deref(),
+                    &located.display.id,
+                    &source.name,
+                )?;
                 let (bytes, cache_path) =
                     self.get_or_fetch_rest_manifest(&source, package_id, &selected.version, &selected.channel)?;
                 let (manifest, manifest_documents) =
@@ -2417,6 +2559,47 @@ impl Repository {
                 Ok((manifest, manifest_documents, vec![cache_path]))
             }
         }
+    }
+
+    fn refresh_preindexed_and_retry_manifest(
+        &mut self,
+        source_index: usize,
+        previous_display: &SearchMatch,
+        query: &PackageQuery,
+        missing_error: anyhow::Error,
+    ) -> Result<(Manifest, JsonValue, Vec<PathBuf>)> {
+        self.refresh_preindexed_source(source_index, true)
+            .with_context(|| format!("{missing_error} The source refresh also failed"))?;
+        let refreshed = self.find_refreshed_preindexed_match(source_index, previous_display, query)?;
+        self.manifest_for_match_with_refresh(&refreshed, query, false)
+    }
+
+    fn find_refreshed_preindexed_match(
+        &mut self,
+        source_index: usize,
+        previous_display: &SearchMatch,
+        query: &PackageQuery,
+    ) -> Result<LocatedMatch> {
+        let source_name = self.store.sources[source_index].name.clone();
+        let mut source_query = query.clone();
+        source_query.source = Some(source_name.clone());
+        let matches = self
+            .search_preindexed(source_index, &source_query, SearchSemantics::Single)?
+            .matches;
+        if let Some(found) = matches
+            .iter()
+            .find(|candidate| candidate.display.id.eq_ignore_ascii_case(&previous_display.id))
+        {
+            return Ok(found.clone());
+        }
+        if matches.len() == 1 {
+            return Ok(matches.into_iter().next().expect("single match"));
+        }
+        bail!(
+            "Package '{}' was not found in source '{}' after refreshing the pre-indexed source.",
+            previous_display.id,
+            source_name
+        )
     }
 
     fn search_preindexed(
@@ -2555,16 +2738,119 @@ impl Repository {
     }
 
     fn open_preindexed_connection(&mut self, source_index: usize) -> Result<Connection> {
+        Ok(self.open_preindexed_connection_with_refresh(source_index)?.connection)
+    }
+
+    fn open_preindexed_connection_with_refresh(&mut self, source_index: usize) -> Result<PreindexedOpenConnection> {
         let source = self.source_clone(source_index);
         let index_path = preindexed_index_path(&self.app_root, &source);
+        let mut refresh = PreindexedRefreshOutcome::default();
         if !index_path.exists() {
-            let _ = self.update_preindexed(source_index)?;
-            if !self.use_system_winget_sources {
-                self.save_store()?;
+            let _ = self.refresh_preindexed_source(source_index, true)?;
+            refresh.attempted = true;
+        } else if self.is_preindexed_index_stale(&source, &index_path) {
+            let lock_key = self.preindexed_refresh_lock_key(&source);
+            if self.has_recent_preindexed_refresh_attempt(&lock_key) {
+                refresh.attempted = true;
+                refresh.reused_recent_attempt = true;
+            } else {
+                refresh.attempted = true;
+                if let Err(error) = self.refresh_preindexed_source(source_index, false) {
+                    refresh.error = Some(format!("{error:#}"));
+                }
             }
         }
 
-        Self::open_sqlite_connection(index_path).context("failed to open preindexed index")
+        Ok(PreindexedOpenConnection {
+            connection: Self::open_sqlite_connection(index_path).context("failed to open preindexed index")?,
+            refresh,
+        })
+    }
+
+    fn is_preindexed_index_stale(&self, source: &SourceRecord, index_path: &Path) -> bool {
+        let Some(interval) = self.pre_indexed_source_auto_update_interval else {
+            return false;
+        };
+
+        let last_update = source.last_update.or_else(|| {
+            fs::metadata(index_path)
+                .ok()
+                .and_then(|metadata| metadata.modified().ok())
+                .map(DateTime::<Utc>::from)
+        });
+
+        match last_update {
+            Some(last_update) => Utc::now() - last_update >= interval,
+            None => true,
+        }
+    }
+
+    fn preindexed_refresh_lock_key(&self, source: &SourceRecord) -> String {
+        format!("{}|{}|{}", self.app_root.display(), source.identifier, source.name)
+    }
+
+    fn has_recent_preindexed_refresh_attempt(&self, lock_key: &str) -> bool {
+        self.preindexed_refresh_attempts.get(lock_key).is_some_and(|attempt| {
+            Utc::now() - attempt.attempted_at < Duration::minutes(PREINDEXED_REFRESH_RETRY_MINUTES)
+        })
+    }
+
+    fn has_recent_successful_preindexed_refresh_attempt(&self, lock_key: &str) -> bool {
+        self.preindexed_refresh_attempts.get(lock_key).is_some_and(|attempt| {
+            attempt.succeeded && Utc::now() - attempt.attempted_at < Duration::minutes(PREINDEXED_REFRESH_RETRY_MINUTES)
+        })
+    }
+
+    fn record_preindexed_refresh_attempt(&mut self, lock_key: String, succeeded: bool) {
+        self.preindexed_refresh_attempts.insert(
+            lock_key,
+            PreindexedRefreshAttempt {
+                attempted_at: Utc::now(),
+                succeeded,
+            },
+        );
+    }
+
+    fn preindexed_refresh_lock(lock_key: &str) -> Result<Arc<Mutex<()>>> {
+        {
+            let locks = preindexed_refresh_locks()
+                .read()
+                .map_err(|_| anyhow!("pre-indexed refresh lock registry was poisoned"))?;
+            if let Some(existing) = locks.get(lock_key) {
+                return Ok(Arc::clone(existing));
+            }
+        }
+
+        let mut locks = preindexed_refresh_locks()
+            .write()
+            .map_err(|_| anyhow!("pre-indexed refresh lock registry was poisoned"))?;
+        Ok(Arc::clone(
+            locks
+                .entry(lock_key.to_owned())
+                .or_insert_with(|| Arc::new(Mutex::new(()))),
+        ))
+    }
+
+    fn refresh_preindexed_source(&mut self, source_index: usize, force: bool) -> Result<String> {
+        let source = self.source_clone(source_index);
+        let index_path = preindexed_index_path(&self.app_root, &source);
+        let lock_key = self.preindexed_refresh_lock_key(&source);
+        let refresh_lock = Self::preindexed_refresh_lock(&lock_key)?;
+        let _guard = refresh_lock
+            .lock()
+            .map_err(|_| anyhow!("pre-indexed source refresh lock was poisoned"))?;
+
+        if !force && index_path.exists() && !self.is_preindexed_index_stale(&source, &index_path) {
+            return Ok("source already refreshed".to_owned());
+        }
+
+        let result = self.update_preindexed(source_index);
+        self.record_preindexed_refresh_attempt(lock_key, result.is_ok());
+        let detail = result?;
+        if !self.use_system_winget_sources {
+            self.save_store()?;
+        }
+        Ok(detail)
     }
 
     fn open_sqlite_connection(path: PathBuf) -> Result<Connection> {
@@ -2598,8 +2884,20 @@ impl Repository {
 
                     fs::write(preindexed_package_path(&self.app_root, source), &payload)
                         .context("failed to persist source package")?;
-                    fs::write(preindexed_index_path(&self.app_root, source), index_bytes)
-                        .context("failed to persist source index")?;
+                    let index_path = preindexed_index_path(&self.app_root, source);
+                    let temp_index_path = state_dir.join(format!(
+                        "index.{}.tmp",
+                        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+                    ));
+                    fs::write(&temp_index_path, index_bytes).context("failed to persist temporary source index")?;
+                    match fs::rename(&temp_index_path, &index_path) {
+                        Ok(()) => {}
+                        Err(_) if index_path.exists() => {
+                            fs::remove_file(&index_path).context("failed to replace existing source index")?;
+                            fs::rename(&temp_index_path, &index_path).context("failed to replace source index")?;
+                        }
+                        Err(error) => return Err(error).context("failed to persist source index"),
+                    }
                     source.last_update = Some(Utc::now());
                     source.source_version = header_version;
                     return Ok(format!("downloaded {}", candidate));
@@ -2990,7 +3288,6 @@ fn installed_package_matches_upgrade_filter(package: &InstalledPackage, query: &
 /// untouched; they can't appear in `upgrade` output anyway (the upgrade
 /// filter requires a correlation), so they're effectively a no-op here.
 fn dedupe_correlated_for_upgrade(packages: Vec<InstalledPackage>) -> Vec<InstalledPackage> {
-    use std::collections::HashMap;
     let mut by_id: HashMap<(String, String), InstalledPackage> = HashMap::new();
     let mut uncorrelated: Vec<InstalledPackage> = Vec::new();
 
@@ -3609,8 +3906,7 @@ fn collect_installed_packages(scope: Option<&str>) -> Result<Vec<InstalledPackag
 /// by the flipped UpgradeCode GUID, and each subkey's *value names* are the
 /// flipped ProductCodes registered under that UpgradeCode.
 #[cfg(windows)]
-fn collect_msi_upgrade_codes(include_machine: bool, include_user: bool) -> std::collections::HashMap<String, String> {
-    use std::collections::HashMap;
+fn collect_msi_upgrade_codes(include_machine: bool, include_user: bool) -> HashMap<String, String> {
     let mut map = HashMap::new();
     if include_machine {
         collect_msi_upgrade_codes_from(
@@ -3632,12 +3928,7 @@ fn collect_msi_upgrade_codes(include_machine: bool, include_user: bool) -> std::
 }
 
 #[cfg(windows)]
-fn collect_msi_upgrade_codes_from(
-    root: RegKey,
-    path: &str,
-    flags: u32,
-    map: &mut std::collections::HashMap<String, String>,
-) {
+fn collect_msi_upgrade_codes_from(root: RegKey, path: &str, flags: u32, map: &mut HashMap<String, String>) {
     let Ok(upgrade_codes) = root.open_subkey_with_flags(path, flags) else {
         return;
     };
@@ -3699,7 +3990,7 @@ fn collect_installed_packages(_scope: Option<&str>) -> Result<Vec<InstalledPacka
 fn collect_uninstall_view(
     packages: &mut Vec<InstalledPackage>,
     seen: &mut BTreeSet<String>,
-    upgrade_code_map: &std::collections::HashMap<String, String>,
+    upgrade_code_map: &HashMap<String, String>,
     root: RegKey,
     scope: &str,
     arch: &str,
@@ -7059,6 +7350,8 @@ fn select_v1_version(
     versions: &[V1VersionRow],
     requested_version: Option<&str>,
     requested_channel: Option<&str>,
+    package_id: &str,
+    source_name: &str,
 ) -> Result<V1VersionRow> {
     let mut ordered = versions.to_vec();
     ordered.sort_by(|left, right| {
@@ -7074,7 +7367,17 @@ fn select_v1_version(
                     && (channel.is_empty() || candidate.channel.eq_ignore_ascii_case(channel))
             })
             .cloned()
-            .ok_or_else(|| anyhow!("requested version {version} was not found"));
+            .ok_or_else(|| missing_package_version(package_id, source_name, version, requested_channel));
+    }
+
+    if let Some(channel) = requested_channel {
+        return ordered
+            .iter()
+            .find(|candidate| candidate.channel.eq_ignore_ascii_case(channel))
+            .cloned()
+            .ok_or_else(|| {
+                anyhow!("Channel '{channel}' was not found for package '{package_id}' in source '{source_name}'.")
+            });
     }
 
     ordered
@@ -7086,16 +7389,25 @@ fn select_v1_version(
 fn select_v2_version(
     versions: &[PackageVersionDataEntry],
     requested_version: Option<&str>,
+    requested_channel: Option<&str>,
+    package_id: &str,
+    source_name: &str,
 ) -> Result<PackageVersionDataEntry> {
     let mut ordered = versions.to_vec();
     ordered.sort_by(|left, right| compare_version(&right.version, &left.version));
+
+    if let Some(channel) = requested_channel {
+        bail!(
+            "Channel '{channel}' cannot be matched for package '{package_id}' in pre-indexed V2 source '{source_name}' because the local source index does not include channel metadata."
+        );
+    }
 
     if let Some(version) = requested_version {
         return ordered
             .iter()
             .find(|candidate| candidate.version.eq_ignore_ascii_case(version))
             .cloned()
-            .ok_or_else(|| anyhow!("requested version {version} was not found"));
+            .ok_or_else(|| missing_package_version(package_id, source_name, version, requested_channel));
     }
 
     ordered
@@ -7104,10 +7416,35 @@ fn select_v2_version(
         .ok_or_else(|| anyhow!("package had no V2 versions"))
 }
 
+fn missing_package_version(
+    package_id: &str,
+    source_name: &str,
+    requested_version: &str,
+    requested_channel: Option<&str>,
+) -> anyhow::Error {
+    anyhow!(MissingPackageVersionError {
+        package_id: package_id.to_owned(),
+        source_name: source_name.to_owned(),
+        requested_version: requested_version.to_owned(),
+        requested_channel: requested_channel.map(str::to_owned),
+    })
+}
+
+fn missing_error_after_open_refresh<T>(error: anyhow::Error, refresh: &PreindexedRefreshOutcome) -> Result<T> {
+    if let Some(refresh_error) = refresh.error.as_deref() {
+        let missing_error = error.to_string();
+        return Err(error).with_context(|| format!("{missing_error} The source refresh also failed: {refresh_error}"));
+    }
+
+    Err(error)
+}
+
 fn select_rest_version<'a>(
     versions: &'a [VersionKey],
     requested_version: Option<&str>,
     requested_channel: Option<&str>,
+    package_id: &str,
+    source_name: &str,
 ) -> Result<&'a VersionKey> {
     if let Some(version) = requested_version {
         let channel = requested_channel.unwrap_or_default();
@@ -7117,7 +7454,16 @@ fn select_rest_version<'a>(
                 candidate.version.eq_ignore_ascii_case(version)
                     && (channel.is_empty() || candidate.channel.eq_ignore_ascii_case(channel))
             })
-            .ok_or_else(|| anyhow!("requested version {version} was not found"));
+            .ok_or_else(|| missing_package_version(package_id, source_name, version, requested_channel));
+    }
+
+    if let Some(channel) = requested_channel {
+        return versions
+            .iter()
+            .find(|candidate| candidate.channel.eq_ignore_ascii_case(channel))
+            .ok_or_else(|| {
+                anyhow!("Channel '{channel}' was not found for package '{package_id}' in source '{source_name}'.")
+            });
     }
 
     versions.first().ok_or_else(|| anyhow!("package had no REST versions"))
@@ -8509,11 +8855,15 @@ fn write_portable_arp_entry(entry: &PortableArpEntry<'_>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
+    use std::io::{Read as _, Write};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
+    use std::thread::{self, JoinHandle};
 
     use flate2::Compression;
     use flate2::write::DeflateEncoder;
+    use zip::write::SimpleFileOptions;
 
     use super::*;
 
@@ -8655,9 +9005,11 @@ mod tests {
     }
 
     fn temp_app_root(label: &str) -> PathBuf {
+        static TEMP_APP_ROOT_COUNTER: AtomicU64 = AtomicU64::new(0);
         std::env::temp_dir().join(format!(
-            "pinget-rs-tests-{label}-{}",
-            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+            "pinget-rs-tests-{label}-{}-{}",
+            std::process::id(),
+            TEMP_APP_ROOT_COUNTER.fetch_add(1, AtomicOrdering::SeqCst)
         ))
     }
 
@@ -8900,11 +9252,13 @@ mod tests {
 
     #[test]
     fn repository_options_capture_custom_host_settings() {
-        let options =
-            RepositoryOptions::new(PathBuf::from(r"C:\temp\pinget-test")).with_user_agent("pinget-rs-tests/1.0");
+        let options = RepositoryOptions::new(PathBuf::from(r"C:\temp\pinget-test"))
+            .with_user_agent("pinget-rs-tests/1.0")
+            .with_pre_indexed_source_auto_update_interval(None);
 
         assert_eq!(options.app_root, PathBuf::from(r"C:\temp\pinget-test"));
         assert_eq!(options.user_agent, "pinget-rs-tests/1.0");
+        assert!(options.pre_indexed_source_auto_update_interval.is_none());
     }
 
     #[test]
@@ -11699,6 +12053,442 @@ Installers:
             arp_min_version: arp_min.map(str::to_owned),
             arp_max_version: arp_max.map(str::to_owned),
         }
+    }
+
+    fn v1_version(version: &str, channel: &str) -> V1VersionRow {
+        V1VersionRow {
+            version: version.to_owned(),
+            channel: channel.to_owned(),
+            pathpart_id: 0,
+            manifest_hash: None,
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestHttpResponse {
+        status: u16,
+        body: Vec<u8>,
+        source_version: Option<String>,
+    }
+
+    struct TestHttpServer {
+        addr: SocketAddr,
+        routes: Arc<Mutex<HashMap<String, TestHttpResponse>>>,
+        counts: Arc<Mutex<HashMap<String, usize>>>,
+        running: Arc<AtomicBool>,
+        handle: Option<JoinHandle<()>>,
+    }
+
+    impl TestHttpServer {
+        fn start() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind test HTTP server");
+            let addr = listener.local_addr().expect("test HTTP server address");
+            let routes = Arc::new(Mutex::new(HashMap::new()));
+            let counts = Arc::new(Mutex::new(HashMap::new()));
+            let running = Arc::new(AtomicBool::new(true));
+            let thread_routes = Arc::clone(&routes);
+            let thread_counts = Arc::clone(&counts);
+            let thread_running = Arc::clone(&running);
+            let handle = thread::spawn(move || {
+                while thread_running.load(AtomicOrdering::SeqCst) {
+                    let Ok((stream, _)) = listener.accept() else {
+                        continue;
+                    };
+                    handle_test_http_request(stream, &thread_routes, &thread_counts);
+                }
+            });
+
+            Self {
+                addr,
+                routes,
+                counts,
+                running,
+                handle: Some(handle),
+            }
+        }
+
+        fn url(&self) -> String {
+            format!("http://{}", self.addr)
+        }
+
+        fn set_bytes(&self, path: &str, body: Vec<u8>) {
+            self.set_response(
+                path,
+                TestHttpResponse {
+                    status: 200,
+                    body,
+                    source_version: None,
+                },
+            );
+        }
+
+        fn set_source_package(&self, body: Vec<u8>, source_version: &str) {
+            self.set_response(
+                "/source.msix",
+                TestHttpResponse {
+                    status: 200,
+                    body,
+                    source_version: Some(source_version.to_owned()),
+                },
+            );
+        }
+
+        fn set_status(&self, path: &str, status: u16) {
+            self.set_response(
+                path,
+                TestHttpResponse {
+                    status,
+                    body: Vec::new(),
+                    source_version: None,
+                },
+            );
+        }
+
+        fn set_response(&self, path: &str, response: TestHttpResponse) {
+            self.routes
+                .lock()
+                .expect("test HTTP routes")
+                .insert(path.to_owned(), response);
+        }
+
+        fn request_count(&self, path: &str) -> usize {
+            self.counts
+                .lock()
+                .expect("test HTTP counts")
+                .get(path)
+                .copied()
+                .unwrap_or_default()
+        }
+    }
+
+    impl Drop for TestHttpServer {
+        fn drop(&mut self) {
+            self.running.store(false, AtomicOrdering::SeqCst);
+            let _ = TcpStream::connect(self.addr);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn handle_test_http_request(
+        mut stream: TcpStream,
+        routes: &Arc<Mutex<HashMap<String, TestHttpResponse>>>,
+        counts: &Arc<Mutex<HashMap<String, usize>>>,
+    ) {
+        let mut buffer = [0u8; 2048];
+        let read = stream.read(&mut buffer).unwrap_or(0);
+        let request = String::from_utf8_lossy(&buffer[..read]);
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("/");
+        *counts
+            .lock()
+            .expect("test HTTP counts")
+            .entry(path.to_owned())
+            .or_default() += 1;
+        let response = routes.lock().expect("test HTTP routes").get(path).cloned();
+        let response = response.unwrap_or(TestHttpResponse {
+            status: 404,
+            body: Vec::new(),
+            source_version: None,
+        });
+        let reason = if response.status == 200 { "OK" } else { "Not Found" };
+        let mut headers = format!(
+            "HTTP/1.1 {} {}\r\nContent-Length: {}\r\nConnection: close\r\n",
+            response.status,
+            reason,
+            response.body.len()
+        );
+        if let Some(source_version) = response.source_version {
+            headers.push_str(&format!("x-ms-meta-sourceversion: {source_version}\r\n"));
+        }
+        headers.push_str("\r\n");
+        stream.write_all(headers.as_bytes()).expect("write test HTTP headers");
+        stream.write_all(&response.body).expect("write test HTTP body");
+    }
+
+    fn test_source_record(source_url: String) -> SourceRecord {
+        SourceRecord {
+            name: "test-winget".to_owned(),
+            kind: SourceKind::PreIndexed,
+            arg: source_url,
+            identifier: "Test.Source".to_owned(),
+            trust_level: "Trusted".to_owned(),
+            explicit: false,
+            priority: 0,
+            last_update: Some(Utc::now()),
+            source_version: None,
+        }
+    }
+
+    fn open_test_preindexed_repository(
+        app_root: &Path,
+        source: &SourceRecord,
+        interval: Option<Duration>,
+    ) -> Repository {
+        fs::create_dir_all(app_root).expect("create app root");
+        save_store(
+            app_root,
+            &SourceStore {
+                sources: vec![source.clone()],
+            },
+        )
+        .expect("save source store");
+        Repository::open_with_options(
+            RepositoryOptions::new(app_root.to_path_buf()).with_pre_indexed_source_auto_update_interval(interval),
+        )
+        .expect("open repository")
+    }
+
+    fn write_test_preindexed_index(app_root: &Path, source: &SourceRecord, versions: &[&str]) {
+        let index_path = preindexed_index_path(app_root, source);
+        if let Some(parent) = index_path.parent() {
+            fs::create_dir_all(parent).expect("create source state directory");
+        }
+        fs::write(index_path, make_v1_index_bytes(versions)).expect("write preindexed index");
+    }
+
+    fn make_source_package(versions: &[&str]) -> Vec<u8> {
+        let cursor = Cursor::new(Vec::new());
+        let mut archive = zip::ZipWriter::new(cursor);
+        let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        archive
+            .start_file("Public/index.db", options)
+            .expect("start index entry");
+        archive
+            .write_all(&make_v1_index_bytes(versions))
+            .expect("write index entry");
+        archive.finish().expect("finish source package").into_inner()
+    }
+
+    fn make_v1_index_bytes(versions: &[&str]) -> Vec<u8> {
+        let root = temp_app_root("preindexed_index_bytes");
+        fs::create_dir_all(&root).expect("create index temp root");
+        let db_path = root.join("index.db");
+        let connection = Repository::open_sqlite_connection(db_path.clone()).expect("open index db");
+        let mut sql = String::from(
+            "CREATE TABLE ids (id TEXT);
+             CREATE TABLE names (name TEXT);
+             CREATE TABLE monikers (moniker TEXT);
+             CREATE TABLE versions (version TEXT);
+             CREATE TABLE channels (channel TEXT);
+             CREATE TABLE pathparts (parent INT64, pathpart TEXT);
+             CREATE TABLE manifest (
+                 id INT64,
+                 name INT64,
+                 moniker INT64,
+                 version INT64,
+                 channel INT64,
+                 pathpart INT64
+             );
+             INSERT INTO ids(rowid, id) VALUES (1, 'Test.Package');
+             INSERT INTO names(rowid, name) VALUES (1, 'Test Package');
+             INSERT INTO channels(rowid, channel) VALUES (1, '');
+             INSERT INTO pathparts(rowid, parent, pathpart) VALUES (1, NULL, 'manifests');
+             INSERT INTO pathparts(rowid, parent, pathpart) VALUES (2, 1, 'Test.Package.yaml');",
+        );
+        for (index, version) in versions.iter().enumerate() {
+            let rowid = index + 1;
+            sql.push_str(&format!(
+                "INSERT INTO versions(rowid, version) VALUES ({rowid}, '{version}');
+                 INSERT INTO manifest(id, name, moniker, version, channel, pathpart) VALUES (1, 1, NULL, {rowid}, 1, 2);"
+            ));
+        }
+        execute_batch_sql(&connection, &sql).expect("seed preindexed V1 database");
+        let _ = query_rows(&connection, "PRAGMA wal_checkpoint(TRUNCATE)", Vec::new(), |_| Ok(()))
+            .expect("checkpoint preindexed V1 database");
+        connection.cacheflush().expect("flush preindexed V1 database");
+        drop(connection);
+        let bytes = fs::read(&db_path).expect("read index bytes");
+        let _ = fs::remove_dir_all(root);
+        bytes
+    }
+
+    fn test_manifest_yaml(version: &str) -> Vec<u8> {
+        format!(
+            "PackageIdentifier: Test.Package\nPackageVersion: {version}\nPackageName: Test Package\nPublisher: Test\n"
+        )
+        .into_bytes()
+    }
+
+    fn show_test_package(version: Option<&str>) -> PackageQuery {
+        PackageQuery {
+            id: Some("Test.Package".to_owned()),
+            source: Some("test-winget".to_owned()),
+            exact: true,
+            version: version.map(str::to_owned),
+            ..PackageQuery::default()
+        }
+    }
+
+    #[test]
+    fn preindexed_explicit_missing_version_refreshes_once_and_returns_requested_version() {
+        let app_root = temp_app_root("preindexed_explicit_refresh");
+        let server = TestHttpServer::start();
+        server.set_status("/source2.msix", 404);
+        server.set_source_package(make_source_package(&["1.0.0", "2.0.0"]), "2");
+        server.set_bytes("/manifests/Test.Package.yaml", test_manifest_yaml("2.0.0"));
+        let source = test_source_record(server.url());
+        write_test_preindexed_index(&app_root, &source, &["1.0.0"]);
+        let mut repository = open_test_preindexed_repository(&app_root, &source, None);
+
+        let result = repository
+            .show(&show_test_package(Some("2.0.0")))
+            .expect("show after refresh");
+
+        assert_eq!(result.manifest.version, "2.0.0");
+        assert_eq!(repository.list_sources()[0].source_version.as_deref(), Some("2"));
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn preindexed_explicit_missing_version_fails_after_refresh_instead_of_returning_latest() {
+        let app_root = temp_app_root("preindexed_explicit_still_missing");
+        let server = TestHttpServer::start();
+        server.set_status("/source2.msix", 404);
+        server.set_source_package(make_source_package(&["1.0.0"]), "same");
+        let source = test_source_record(server.url());
+        write_test_preindexed_index(&app_root, &source, &["1.0.0"]);
+        let mut repository = open_test_preindexed_repository(&app_root, &source, None);
+
+        let error = repository
+            .show(&show_test_package(Some("2.0.0")))
+            .expect_err("missing explicit version must fail");
+
+        assert!(format!("{error:#}").contains("2.0.0"));
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn preindexed_stale_index_refreshes_for_latest_requests() {
+        let app_root = temp_app_root("preindexed_ttl_refresh");
+        let server = TestHttpServer::start();
+        server.set_status("/source2.msix", 404);
+        server.set_source_package(make_source_package(&["1.0.0", "2.0.0"]), "fresh");
+        server.set_bytes("/manifests/Test.Package.yaml", test_manifest_yaml("2.0.0"));
+        let mut source = test_source_record(server.url());
+        source.last_update = Some(Utc::now() - Duration::days(2));
+        write_test_preindexed_index(&app_root, &source, &["1.0.0"]);
+        let mut repository = open_test_preindexed_repository(&app_root, &source, Some(Duration::minutes(1)));
+
+        let result = repository
+            .show(&show_test_package(None))
+            .expect("show latest after TTL refresh");
+
+        assert_eq!(result.manifest.version, "2.0.0");
+        assert_eq!(repository.list_sources()[0].source_version.as_deref(), Some("fresh"));
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn preindexed_stale_refresh_failure_falls_back_for_latest_requests() {
+        let app_root = temp_app_root("preindexed_ttl_fallback");
+        let server = TestHttpServer::start();
+        server.set_status("/source2.msix", 404);
+        server.set_status("/source.msix", 404);
+        server.set_bytes("/manifests/Test.Package.yaml", test_manifest_yaml("1.0.0"));
+        let mut source = test_source_record(server.url());
+        source.last_update = Some(Utc::now() - Duration::days(2));
+        write_test_preindexed_index(&app_root, &source, &["1.0.0"]);
+        let mut repository = open_test_preindexed_repository(&app_root, &source, Some(Duration::minutes(1)));
+
+        let result = repository
+            .show(&show_test_package(None))
+            .expect("show latest from stale cache after refresh failure");
+
+        assert_eq!(result.manifest.version, "1.0.0");
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn preindexed_explicit_missing_version_does_not_refresh_twice_after_stale_refresh() {
+        let app_root = temp_app_root("preindexed_no_double_refresh");
+        let server = TestHttpServer::start();
+        server.set_status("/source2.msix", 404);
+        server.set_source_package(make_source_package(&["1.0.0", "2.0.0"]), "fresh");
+        let mut source = test_source_record(server.url());
+        source.last_update = Some(Utc::now() - Duration::days(2));
+        write_test_preindexed_index(&app_root, &source, &["1.0.0"]);
+        let mut repository = open_test_preindexed_repository(&app_root, &source, Some(Duration::minutes(1)));
+
+        let error = repository
+            .show(&show_test_package(Some("3.0.0")))
+            .expect_err("still-missing explicit version must fail after one stale refresh");
+
+        assert!(format!("{error:#}").contains("3.0.0"));
+        assert_eq!(server.request_count("/source.msix"), 1);
+        let _ = fs::remove_dir_all(app_root);
+    }
+
+    #[test]
+    fn select_v2_version_without_explicit_filters_returns_latest() {
+        let versions = vec![
+            version_entry("1.0.0", None, None),
+            version_entry("1.2.0", None, None),
+            version_entry("1.1.0", None, None),
+        ];
+
+        let selected = select_v2_version(&versions, None, None, "Test.Package", "test").expect("latest version");
+
+        assert_eq!(selected.version, "1.2.0");
+    }
+
+    #[test]
+    fn select_v2_version_with_missing_requested_version_throws() {
+        let versions = vec![version_entry("1.2.0", None, None), version_entry("1.1.0", None, None)];
+
+        let error = select_v2_version(&versions, Some("9.9.9"), None, "Test.Package", "test")
+            .expect_err("missing requested version");
+
+        assert!(error.downcast_ref::<MissingPackageVersionError>().is_some());
+        assert!(error.to_string().contains("9.9.9"));
+    }
+
+    #[test]
+    fn select_v2_version_with_requested_channel_throws_instead_of_ignoring_channel() {
+        let versions = vec![version_entry("1.2.0", None, None)];
+
+        let error = select_v2_version(&versions, Some("1.2.0"), Some("beta"), "Test.Package", "test")
+            .expect_err("unsupported channel request");
+
+        assert!(error.to_string().contains("beta"));
+        assert!(error.to_string().contains("channel metadata"));
+    }
+
+    #[test]
+    fn select_v1_version_channel_only_returns_latest_matching_channel() {
+        let versions = vec![
+            v1_version("1.2.0", "stable"),
+            v1_version("1.3.0", "stable"),
+            v1_version("2.0.0", "preview"),
+        ];
+
+        let selected =
+            select_v1_version(&versions, None, Some("stable"), "Test.Package", "test").expect("latest stable version");
+
+        assert_eq!(selected.version, "1.3.0");
+    }
+
+    #[test]
+    fn select_rest_version_channel_mismatch_throws() {
+        let versions = vec![
+            VersionKey {
+                version: "1.2.0".to_owned(),
+                channel: "stable".to_owned(),
+            },
+            VersionKey {
+                version: "1.1.0".to_owned(),
+                channel: "beta".to_owned(),
+            },
+        ];
+
+        let error = select_rest_version(&versions, Some("1.2.0"), Some("beta"), "Test.Package", "test")
+            .expect_err("missing version and channel pair");
+
+        assert!(error.downcast_ref::<MissingPackageVersionError>().is_some());
     }
 
     #[test]

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -8,7 +8,7 @@ use std::io::{Cursor, Read};
 #[cfg(windows)]
 use std::mem::{MaybeUninit, size_of};
 #[cfg(windows)]
-use std::os::windows::ffi::OsStringExt;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
@@ -26,6 +26,8 @@ use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, LocalFree};
 use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
 #[cfg(windows)]
 use windows_sys::Win32::Security::{GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser};
+#[cfg(windows)]
+use windows_sys::Win32::Storage::FileSystem::{MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW};
 #[cfg(windows)]
 use windows_sys::Win32::Storage::Packaging::Appx::GetCurrentPackageFullName;
 #[cfg(windows)]
@@ -2890,14 +2892,7 @@ impl Repository {
                         Utc::now().timestamp_nanos_opt().unwrap_or_default()
                     ));
                     fs::write(&temp_index_path, index_bytes).context("failed to persist temporary source index")?;
-                    match fs::rename(&temp_index_path, &index_path) {
-                        Ok(()) => {}
-                        Err(_) if index_path.exists() => {
-                            fs::remove_file(&index_path).context("failed to replace existing source index")?;
-                            fs::rename(&temp_index_path, &index_path).context("failed to replace source index")?;
-                        }
-                        Err(error) => return Err(error).context("failed to persist source index"),
-                    }
+                    replace_file(&temp_index_path, &index_path).context("failed to persist source index")?;
                     source.last_update = Some(Utc::now());
                     source.source_version = header_version;
                     return Ok(format!("downloaded {}", candidate));
@@ -4299,6 +4294,35 @@ fn preindexed_package_path(app_root: &Path, source: &SourceRecord) -> PathBuf {
 
 fn preindexed_index_path(app_root: &Path, source: &SourceRecord) -> PathBuf {
     source_state_dir(app_root, source).join("index.db")
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, target: &Path) -> Result<()> {
+    let source_wide = source
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let target_wide = target
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
+    // SAFETY: Both paths are converted to null-terminated UTF-16 buffers that
+    // live for the duration of the call; MoveFileExW does not retain them.
+    let ok = unsafe { MoveFileExW(source_wide.as_ptr(), target_wide.as_ptr(), flags) };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("failed to replace {} with {}", target.display(), source.display()));
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, target: &Path) -> Result<()> {
+    fs::rename(source, target)
+        .with_context(|| format!("failed to replace {} with {}", target.display(), source.display()))
 }
 
 fn rest_information_cache_path(app_root: &Path, source: &SourceRecord) -> PathBuf {
@@ -12249,6 +12273,21 @@ Installers:
             fs::create_dir_all(parent).expect("create source state directory");
         }
         fs::write(index_path, make_v1_index_bytes(versions)).expect("write preindexed index");
+    }
+
+    #[test]
+    fn replace_file_failure_keeps_existing_target() {
+        let root = temp_app_root("replace_file_failure");
+        fs::create_dir_all(&root).expect("create replace root");
+        let target = root.join("index.db");
+        let missing_source = root.join("missing.tmp");
+        fs::write(&target, b"old-index").expect("write existing target");
+
+        let error = replace_file(&missing_source, &target).expect_err("missing replacement should fail");
+
+        assert!(format!("{error:#}").contains("failed to replace"));
+        assert_eq!(fs::read(&target).expect("existing target remains"), b"old-index");
+        let _ = fs::remove_dir_all(root);
     }
 
     fn make_source_package(versions: &[&str]) -> Vec<u8> {


### PR DESCRIPTION
## Summary

Fixes stale WinGet package details for explicit version/channel requests in both the C# and Rust implementations.

- Stops explicit version requests from silently falling back to the latest available manifest when the requested version is missing.
- Adds bounded pre-indexed source refresh/retry behavior for explicit version misses so stale local indexes can recover once, then fail clearly if the version is still unavailable.
- Adds pre-indexed freshness policy support for existing indexes, with stale-cache fallback for non-explicit/latest requests when refresh fails.
- Preserves latest-version behavior when no explicit version/channel is requested.
- Prevents repeated source downloads for a single explicit request after a fresh stale-index refresh already ran.
- Replaces pre-indexed `index.db` through a temporary file in both implementations to avoid partially written active indexes.
- Handles V2 pre-indexed channel requests explicitly instead of ignoring unavailable channel metadata.

## C# changes

- Added `RepositoryOptions.PreIndexedSourceAutoUpdateInterval` and `MissingPackageVersionException`.
- Updated V1, V2, and REST version selection to require exact explicit version/channel matches.
- Added pre-indexed TTL refresh, refresh attempt tracking, per-source refresh locking, diagnostics, and refresh-on-explicit-miss retry.
- Uses read-only SQLite with `Pooling=False` for pre-indexed reads so refresh replacement is safe on Windows.
- Added tests for strict version selection, REST misses, stale index refresh, stale fallback, refresh failure recovery, no double-refresh, and V2 channel rejection.

## Rust changes

- Added `RepositoryOptions.pre_indexed_source_auto_update_interval` with builder support.
- Added strict V1/V2/REST version selection and a focused missing-version error.
- Added pre-indexed TTL refresh, bounded explicit-miss refresh/retry, recent refresh throttling, per-source refresh locks, and safe temp-file index replacement.
- Added an in-process fake pre-indexed source regression harness covering cache/indexing behavior end-to-end.
- Added tests for explicit miss refresh, still-missing failures, TTL refresh, stale fallback, no double-refresh, and exact/channel selectors.

## Validation

- `dotnet format dotnet\Devolutions.Pinget.slnx --verbosity minimal`
- `dotnet test dotnet\src\Devolutions.Pinget.Core.Tests\Devolutions.Pinget.Core.Tests.csproj -c Release --no-restore` — 180 total, 179 passed, 1 skipped
- `dotnet build dotnet\Devolutions.Pinget.slnx -c Release --no-restore`
- `pwsh -NoLogo -NoProfile -File (Resolve-Path 'dotnet\tests\RunTests.ps1')` — 13 passed
- `cargo +nightly fmt --manifest-path rust\Cargo.toml --all`
- `cargo clippy -q --manifest-path rust\Cargo.toml --workspace --tests -- -D warnings`
- `cargo test -p pinget-core --manifest-path rust\Cargo.toml` — 151 passed
- `cargo test -p pinget-cli --manifest-path rust\Cargo.toml` — 9 passed
- `cargo build -p pinget-cli --manifest-path rust\Cargo.toml`
- `git --no-pager diff --check`