### PR TITLE
Optimize Rust release binary size

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -66,3 +66,10 @@ wildcard_dependencies = "warn"
 print_stderr = "warn"
 print_stdout = "warn"
 dbg_macro = "warn"
+
+[profile.release]
+strip = "symbols"
+codegen-units = 1
+lto = true
+opt-level = "z"
+panic = "abort"

--- a/rust/crates/pinget-cli/Cargo.toml
+++ b/rust/crates/pinget-cli/Cargo.toml
@@ -16,8 +16,7 @@ clap = { version = "4.6.1", features = ["derive"] }
 pinget-core = { version = "0.9.0", path = "../pinget-core" }
 chrono = "0.4.44"
 dirs = "6.0"
-jsonschema = "0.30"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+jsonschema = { version = "0.30", default-features = false, features = ["resolve-file"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml = "0.9"

--- a/rust/crates/pinget-core/Cargo.toml
+++ b/rust/crates/pinget-core/Cargo.toml
@@ -20,7 +20,7 @@ flate2 = "1.1.9"
 # those, but fancy-regex's backtracking engine does. Performance is fine for
 # the one-shot normalize call per installed package.
 fancy-regex = "0.16"
-reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "json", "query", "rustls"] }
+reqwest = { version = "0.13.2", default-features = false, features = ["blocking", "query", "rustls"] }
 pollster = "0.4.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/rust/crates/pinget-core/src/lib.rs
+++ b/rust/crates/pinget-core/src/lib.rs
@@ -18,8 +18,8 @@ use chrono::{DateTime, Duration, Utc};
 use reqwest::StatusCode;
 use reqwest::blocking::{Client, Response};
 use reqwest::header::{
-    ACCEPT_ENCODING, CONTENT_LENGTH, CONTENT_RANGE, ETAG, HeaderMap, HeaderValue, IF_MODIFIED_SINCE, IF_NONE_MATCH,
-    IF_RANGE, LAST_MODIFIED, RANGE,
+    ACCEPT_ENCODING, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, ETAG, HeaderMap, HeaderValue, IF_MODIFIED_SINCE,
+    IF_NONE_MATCH, IF_RANGE, LAST_MODIFIED, RANGE,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -3121,14 +3121,15 @@ impl Repository {
             .client
             .post(url)
             .header("Version", contract)
-            .json(&body)
+            .header(CONTENT_TYPE, "application/json")
+            .body(serde_json::to_vec(&body).context("failed to serialize REST search request")?)
             .send()
             .context("REST search request failed")?
             .error_for_status()
             .context("REST search request returned an error")?;
-        let json = response
-            .json::<JsonValue>()
-            .context("failed to parse REST search response")?;
+        let json =
+            serde_json::from_slice::<JsonValue>(&response.bytes().context("failed to read REST search response")?)
+                .context("failed to parse REST search response")?;
         let data = json
             .get("Data")
             .and_then(JsonValue::as_array)
@@ -3455,9 +3456,9 @@ impl Repository {
             .context("REST information request returned an error")?;
 
         let max_age = cache_control_max_age(&response);
-        let json = response
-            .json::<JsonValue>()
-            .context("failed to parse REST information response")?;
+        let json =
+            serde_json::from_slice::<JsonValue>(&response.bytes().context("failed to read REST information response")?)
+                .context("failed to parse REST information response")?;
         let data = json
             .get("Data")
             .cloned()


### PR DESCRIPTION
## Summary
- Add size-focused release profile settings for the Rust workspace: symbol stripping, LTO, single codegen unit, `opt-level = "z"`, and aborting panics
- Disable jsonschema's unused HTTP resolver and remove the unused CLI reqwest dependency
- Remove reqwest's JSON feature from pinget-core by using existing serde_json serialization/parsing in REST paths

## Size impact
- Baseline `cargo build -q -p pinget-cli --manifest-path rust\Cargo.toml --release`: **28,922,368 bytes** (**27.58 MiB**)
- Optimized release build: **11,576,320 bytes** (**11.04 MiB**)
- Reduction: **17,346,048 bytes** (**16.54 MiB**), about **60% smaller**

## Validation
- `cargo +nightly fmt --manifest-path rust\Cargo.toml --all`
- `cargo clippy -q --manifest-path rust\Cargo.toml --workspace --tests -- -D warnings`
- `cargo test -p pinget-core --manifest-path rust\Cargo.toml`
- `cargo test -p pinget-cli --manifest-path rust\Cargo.toml`
- `cargo build -q -p pinget-cli --manifest-path rust\Cargo.toml --release`